### PR TITLE
OSS prep: track CODE_OF_CONDUCT + CONTRIBUTING, repoint URLs to hoffresearch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,6 @@ data/measure/*.nest-*
 # Tracked. Earlier sessions had it gitignored, which silently dropped
 # every architectural decision committed there. Fixed 2026-04-28.
 
-# CODE_OF_CONDUCT.md / CONTRIBUTING.md are still empty templates from
-# the upstream init; tracking them as-is would publish placeholders.
-CODE_OF_CONDUCT.md
-CONTRIBUTING.md
+# CODE_OF_CONDUCT.md and CONTRIBUTING.md were template placeholders
+# at session start and excluded from tracking. The 2026-04-28 audit
+# pass replaced them with real content; they are tracked now.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,27 @@
+# Code of Conduct
+
+## Our Pledge
+
+We are committed to providing a welcoming, inclusive, and harassment-free environment for everyone, regardless of background, identity, or experience level.
+
+## Expected Behavior
+
+- Be respectful and constructive in communication.
+- Accept feedback gracefully and offer it thoughtfully.
+- Focus on what is best for the project and community.
+
+## Unacceptable Behavior
+
+- Harassment, intimidation, or discrimination of any kind.
+- Personal attacks, trolling, or deliberately inflammatory remarks.
+- Publishing others' private information without consent.
+
+## Enforcement
+
+Instances of unacceptable behavior can be reported to [brenner@hoffresearch.com](mailto:brenner@hoffresearch.com). All reports will be reviewed and handled confidentially by the project maintainer.
+
+Maintainers who do not follow or enforce this Code of Conduct may face temporary or permanent consequences as determined by Hoff Research.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thanks for your interest in improving `nest`. All contributions are valued.
 
 ## How to contribute
 
-1. Fork the repository at https://github.com/brennercruvinel/nest.
+1. Fork the repository at https://github.com/hoffresearch/nest.
 2. Create a feature branch from `dev`:
    `git checkout -b feature/short-description`.
 3. Make your changes, keeping each PR focused on one concern.
@@ -20,7 +20,7 @@ Thanks for your interest in improving `nest`. All contributions are valued.
 Requires Rust edition 2024 (`rustc >= 1.85`) and Python 3.12+.
 
 ```bash
-git clone https://github.com/brennercruvinel/nest.git
+git clone https://github.com/hoffresearch/nest.git
 cd nest
 
 # build the rust workspace + PyO3 extension
@@ -70,7 +70,7 @@ python tests/test_search_text_model_hash.py
 
 ## Reporting issues
 
-- Bugs and feature requests: [GitHub Issues](https://github.com/brennercruvinel/nest/issues).
+- Bugs and feature requests: [GitHub Issues](https://github.com/hoffresearch/nest/issues).
 - Security vulnerabilities: please do **not** open a public issue. Email [brenner@hoffresearch.com](mailto:brenner@hoffresearch.com) directly. We aim to acknowledge within 72 hours.
 - Questions about the format itself: open a discussion or check `SPEC.md` and `kdb/adr/`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,88 @@
+# Contributing to nest
+
+Thanks for your interest in improving `nest`. All contributions are valued.
+
+`nest` is maintained by [Hoff Research](https://hoffresearch.com). Author and current maintainer: Brenner Cruvinel ([brenner@hoffresearch.com](mailto:brenner@hoffresearch.com)).
+
+## How to contribute
+
+1. Fork the repository at https://github.com/brennercruvinel/nest.
+2. Create a feature branch from `dev`:
+   `git checkout -b feature/short-description`.
+3. Make your changes, keeping each PR focused on one concern.
+4. Add or update tests for the change. The bar is `cargo test --workspace` and `python tests/test_e2e.py` both green; new behavior needs a new test.
+5. Run `./scripts/release_check.sh` locally before pushing. It runs the full pipeline (build, test, clippy, fmt, ruff, line-count guard, regression gates) and is what CI runs on the PR.
+6. Commit with a descriptive message. We use plain English, no Conventional Commits prefix.
+7. Open a Pull Request against `dev`. The maintainer rebases or squashes into `main` at release time.
+
+## Development setup
+
+Requires Rust edition 2024 (`rustc >= 1.85`) and Python 3.12+.
+
+```bash
+git clone https://github.com/brennercruvinel/nest.git
+cd nest
+
+# build the rust workspace + PyO3 extension
+cargo build --release --workspace
+cp target/release/lib_nest.dylib python/_nest.so   # macOS
+cp target/release/lib_nest.so   python/_nest.so    # linux
+
+# python deps for the build/test side
+python3 -m venv .venv && source .venv/bin/activate
+pip install ruff sentence-transformers pandas zstandard pyarrow
+```
+
+The corpus and embedding cache under `database/` are tracked via Git LFS. Expect a one-time `git lfs pull` of around 600 MB on first checkout. Without LFS the public datasets are skipped, the runtime tests still pass.
+
+## Code style
+
+### Rust
+
+- Edition 2024, `cargo fmt --all` enforced (`rustfmt.toml` pins the rules).
+- `cargo clippy --workspace --all-targets -- -D warnings` is a hard error gate. Suppress an individual lint with `#[allow(clippy::name_of_lint)]` and a one-line justification, never with a global allow.
+- Every `unsafe` block needs a `// SAFETY:` comment that names the invariant the caller is relying on.
+- Public items get a doc comment that explains the why, not the what. The function name already says what.
+- Files in `crates/**/src/**` cap at 300 lines (see `kdb/adr/0011`). Test files (`crates/**/tests/*.rs`) are exempt.
+
+### Python
+
+- Target version `py312`, line length 100, ruff config in `pyproject.toml`.
+- Lints: `E F W I B UP SIM`. Run `ruff check .` and `ruff format --check .`.
+- Private helpers in `python/tools/` are prefixed with `_` (e.g. `_baseline_decoder.py`) to signal "internal to tools, do not import elsewhere".
+- Same 300-line cap applies to first-party modules.
+
+### Format / runtime invariants
+
+If a change touches the binary container layout, the search contract, hash semantics, or the model fingerprint, write or update an ADR under `kdb/adr/`. The format is frozen at v1; any byte-level change has to either fit inside v1 (new section IDs are reserved, encodings 4-255 are reserved) or bump `NEST_FORMAT_VERSION` and ship as v2.
+
+## Tests
+
+```bash
+cargo test --release --workspace
+python tests/test_e2e.py
+python tests/test_builder.py
+python tests/test_search_text_model_hash.py
+./scripts/release_check.sh
+```
+
+`release_check.sh` is the source of truth for "PR-ready". If it passes locally, CI passes.
+
+## Reporting issues
+
+- Bugs and feature requests: [GitHub Issues](https://github.com/brennercruvinel/nest/issues).
+- Security vulnerabilities: please do **not** open a public issue. Email [brenner@hoffresearch.com](mailto:brenner@hoffresearch.com) directly. We aim to acknowledge within 72 hours.
+- Questions about the format itself: open a discussion or check `SPEC.md` and `kdb/adr/`.
+
+When reporting a bug, include:
+- the `.nest` `file_hash` and `content_hash` (`nest stats <file>`),
+- the runtime `simd_backend` (`nest stats` prints it),
+- the exact CLI or Python invocation, and the error output.
+
+## Code of Conduct
+
+This project adheres to a [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to uphold it.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE) and that copyright vests in Hoff Research as the project maintainer. The MIT license keeps your right to use, copy, modify, merge, publish, distribute, sublicense, or sell your own copies of the resulting Software intact.


### PR DESCRIPTION
## Summary

Two small commits making the repo OSS-collaboration-ready after the move to the Hoff Research org.

- **`b562ae01`** — track `CODE_OF_CONDUCT.md` + `CONTRIBUTING.md` (were placeholders excluded from VCS via `.gitignore` until now). Real reporting email (`brenner@hoffresearch.com`), real dev setup, real test bar, security-vuln policy, code-style rules per language. Also closes the truncated trailing comment in `.gitignore`.
- **`97d3dfcb`** — repoint the 3 URLs in `CONTRIBUTING.md` from `brennercruvinel/nest` to `hoffresearch/nest`. GitHub auto-redirects, but the canonical link should match where the repo actually lives.

`LICENSE` was already correct (`Copyright (c) 2026 Hoff Research`, MIT). Not touched.

## Test plan

- [x] `cargo test --release --workspace` — 134/134 green (no Rust changes; sanity)
- [x] `python tests/test_e2e.py`, `tests/test_builder.py`, `tests/test_search_text_model_hash.py` — all pass
- [x] `./scripts/release_check.sh` — ALL GATES PASS (last run on `97d3dfcb`)
- [x] No em-dashes / no emoji in the new docs (style audit clean)
- [x] `.gitignore` no longer drops `CODE_OF_CONDUCT.md` / `CONTRIBUTING.md`

## Notes

After this merge, the repo is ready for the OSS prerequisites tier:

- `SECURITY.md` (vuln disclosure policy referencing `brenner@hoffresearch.com`)
- `.github/CODEOWNERS`
- `.github/workflows/release-check.yml` (port of `scripts/release_check.sh`)
- `.github/PULL_REQUEST_TEMPLATE.md`, `.github/ISSUE_TEMPLATE/*`
- `.github/dependabot.yml`

Then the rulesets we discussed (main / dev / `v*` tags / default).