### PR TITLE
adjust old refs: drop kdb/ADR mentions in docs and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -31,7 +31,7 @@ assignees: ''
 
 ## format / runtime impact
 
-<!-- if this touches binary layout, search contract, hash semantics, or model fingerprint, an ADR will be required under kdb/adr/. otherwise: n/a. -->
+<!-- describe any impact on binary layout, search contract, hash semantics, or model fingerprint. otherwise: n/a. -->
 
 n/a
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,7 +24,7 @@
 
 ## format / runtime impact
 
-<!-- if this PR touches the binary layout, the search contract, hash semantics, or the model fingerprint, write or update an ADR under kdb/adr/. otherwise: n/a. -->
+<!-- describe any change to the binary layout, the search contract, hash semantics, or the model fingerprint. otherwise: n/a. -->
 
 n/a
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.so
 *.dylib
 *.dll
+kdb/
 kdb/adr/
 # Python
 __pycache__/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,9 +66,9 @@ python entry: `sys.path.insert(0, "python"); import nest`. dynamic loader finds 
 - four hashes: `header_checksum`, per-section `checksum` (physical bytes), `file_hash` (whole file), `content_hash` (decoded canonical sections, stable across encodings).
 - `NestFileBuilder` is a consuming builder (`add_chunk(self) -> Self`). presets via `.text_encoding()` + `.embedding_dtype()`.
 - HNSW build is deterministic given a seed. BM25 index is sorted by alphabetical term order.
-- `model_hash` is a granular fingerprint over `(model_id, files_hash, tokenizer_hash, pooling_config_hash, embedding_dim, normalize_embeddings)`. zero-placeholder is rejected at write time. see ADR 0008.
+- `model_hash` is a granular fingerprint over `(model_id, files_hash, tokenizer_hash, pooling_config_hash, embedding_dim, normalize_embeddings)`. zero-placeholder is rejected at write time.
 - runtime SIMD dispatch: AVX2 (x86_64), NEON (aarch64), scalar fallback. `NEST_FORCE_SCALAR=1` forces scalar for A/B benchmarks.
-- file hygiene: every rust source file in `crates/**/src/**` and every first-party python module is at most 300 lines. test files and the `crates/nest-format/tests/roundtrip.rs` carve-out are exempt. see ADR 0011.
+- file hygiene: every rust source file in `crates/**/src/**` and every first-party python module is at most 300 lines. test files and the `crates/nest-format/tests/roundtrip.rs` carve-out are exempt.
 - golden fixture: `crates/nest-format/tests/fixtures/golden_v1_minimal.nest` (1366 bytes, byte-frozen).
 - CLI `search` takes JSON f32 array positional arg; `search-text` shells out to `python/embed_query.py` and validates the embedder's `model_hash` against the manifest.
 
@@ -116,7 +116,6 @@ these are documented honest limitations of the current code, not bugs to silentl
 - `doc/architecture.md`: binary layout, API surface, errors, versioning, four hashes, SIMD dispatcher, search contract.
 - `doc/usage.md`: 10-section how-to for the 8 commands, presets, offline mode, citations.
 - `doc/changelog.md`: v0.1.0 and v0.2.0 deltas.
-- `kdb/adr/`: architectural decisions records every product/feature/business irreversible decision lives here.
 - `data/demo/README.md`: what each upstream PT-BR dataset is and how to rebuild the unified corpus.
 - `CONTRIBUTING.md`: external contributor flow.
 - `CODE_OF_CONDUCT.md`: contributor covenant 2.1, lowercase plain-style.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ rust:
 - `cargo clippy --workspace --all-targets -- -D warnings` is a hard gate. suppress an individual lint with `#[allow(clippy::name)]` and a one-line justification, never globally.
 - every `unsafe` block needs a `// SAFETY:` comment naming the invariant the caller is relying on.
 - public items get a doc comment that explains the why, not the what. the name already says what.
-- files in `crates/**/src/**` cap at 300 lines, see `kdb/adr/0011`. test files are exempt.
+- files in `crates/**/src/**` cap at 300 lines. test files are exempt.
 
 python:
 
@@ -49,7 +49,7 @@ python:
 
 format and runtime invariants:
 
-if a change touches the binary container layout, the search contract, hash semantics, or the model fingerprint, write or update an adr under `kdb/adr/`. the format is frozen at v1. any byte-level change either fits inside v1 (new section ids and encodings 4-255 are reserved) or bumps `NEST_FORMAT_VERSION` and ships as v2.
+the format is frozen at v1. any byte-level change either fits inside v1 (new section ids and encodings 4-255 are reserved) or bumps `NEST_FORMAT_VERSION` and ships as v2.
 
 ## tests
 
@@ -67,7 +67,7 @@ python tests/test_search_text_model_hash.py
 
 - bugs and feature requests: [github issues](https://github.com/hoffresearch/nest/issues).
 - security vulns: do not open a public issue. email [brenner@hoffresearch.com](mailto:brenner@hoffresearch.com). target ack within 72 hours.
-- questions about the format: open a discussion, or read `doc/spec.md` and `kdb/adr/`.
+- questions about the format: open a discussion, or read `doc/spec.md`.
 
 bug reports should include the `.nest` `file_hash` and `content_hash` (from `nest stats <file>`), the runtime `simd_backend` (also in `nest stats`), the exact cli or python invocation, and the error output.
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ with `reproducible=True` (the script default) two operators get byte-identical `
 - `data/demo/README.md` for what each upstream dataset is and how to rebuild the corpus
 - `doc/architecture.md` for binary layout, API surface, errors, versioning
 - `doc/usage.md` for the eight commands, presets, offline mode, citations
-- `kdb/adr/` for architectural decision records (0001 through 0011)
 - `doc/changelog.md` for v0.1 to v0.2 deltas
 
 ## license

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -53,6 +53,6 @@ things we do not treat as security bugs:
 ## hardening notes
 
 - the runtime never opens a network socket. queries are answered from `mmap`.
-- `model_hash` is a granular fingerprint over the local model snapshot (config + tokenizer + weights + pooling + dim + normalize). a mismatch fails with a typed error, never silently. see `kdb/adr/0008`.
+- `model_hash` is a granular fingerprint over the local model snapshot (config + tokenizer + weights + pooling + dim + normalize). a mismatch fails with a typed error, never silently.
 - `unsafe` is concentrated in the SIMD dispatcher (`crates/nest-runtime/src/simd/`) and the mmap reader (`crates/nest-runtime/src/mmap_file.rs`). every `unsafe` block carries a `// SAFETY:` comment documenting the invariant.
 - binary releases of `nest-cli` are not yet signed. signed tags are on the v0.3 backlog.

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -213,7 +213,7 @@ python/tools/         ingestion (`nest_build_corpus.py`), regression measurement
 scripts/release_check.sh      end-to-end CI gate
 ```
 
-each crate sub-module is split into directories of files, each at most 300 lines (see `kdb/adr/0011`).
+each crate sub-module is split into directories of files, each at most 300 lines.
 
 ## rust API (nest-format)
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -24,7 +24,7 @@ optional sections (skipped by older readers, not part of `content_hash`):
 CLI:
 
 - `nest search-ann <file> <qvec> -k K --ef N`: force the HNSW path with explicit `ef_search`.
-- `nest search-text <file> "query" -k K [--model-path PATH] [--skip-model-hash-check]`: shells out to `python/embed_query.py`, validates the embedder's `embedding_model`, `embedding_dim`, and `model_hash` against the manifest, then routes to the declared `index_type` (exact, hnsw, hybrid). a model mismatch fails with a typed error, never silently. supersedes ADR 0005.
+- `nest search-text <file> "query" -k K [--model-path PATH] [--skip-model-hash-check]`: shells out to `python/embed_query.py`, validates the embedder's `embedding_model`, `embedding_dim`, and `model_hash` against the manifest, then routes to the declared `index_type` (exact, hnsw, hybrid). a model mismatch fails with a typed error, never silently.
 - `nest benchmark --madvise-cold`: extra benchmark pass calling `posix_madvise(MADV_DONTNEED)` between queries. upper bound on cold-cache latency, not absolute cold (see `MmapNestFile::madvise_cold` for caveats).
 - `nest inspect --json`: structured output mirroring `MmapNestFile::inspect_json` for programmatic consumers.
 
@@ -69,9 +69,7 @@ tooling:
 infrastructure:
 
 - HNSW recall fix: replaced naive `top-m` neighbor selection with `select_neighbors_heuristic` (Malkov-Yashunin Algorithm 4). bumped `DEFAULT_EF_CONSTRUCTION` to 400 to hit recall@10 >= 0.95 at typical corpus sizes.
-- file hygiene cap: every rust source file in `crates/**/src/**` and every first-party python module is at most 300 lines (see `kdb/adr/0011`). test files exempt.
-- ADRs added: 0006 (encodings 1/2/3), 0007 (HNSW + BM25 optional sections), 0008 (granular model_hash fingerprint), 0009 (runtime SIMD dispatch), 0010 (search-text supersedes 0005), 0011 (file hygiene 300-line rule).
-- `kdb/` removed from `.gitignore`. earlier sessions had it gitignored, silently dropping every architectural decision committed there.
+- file hygiene cap: every rust source file in `crates/**/src/**` and every first-party python module is at most 300 lines. test files exempt.
 
 ### test surface
 
@@ -130,7 +128,7 @@ encoding: only `SECTION_ENCODING_RAW = 0` is accepted in v0.1. values `1 = zstd`
 - `file_hash` (footer): full 32-byte `SHA-256(file[0..file_size-40))`, including padding.
 - `content_hash`: 32-byte `SHA-256` over the canonical sections in alphabetical-by-name order, each domain-separated by length-prefixed name and length-prefixed payload. stable across rebuilds of the same content.
 - `chunk_id`: domain-separated `SHA-256` with literal preimage prefix `"nest:chunk_id:v1\n"`. format `sha256:<64 hex chars>`.
-- `model_hash`: caller-supplied; format `sha256:<64 hex chars>` enforced at write time. v0.1 accepted any value matching the regex; v0.2 enforces a real fingerprint (see ADR 0008).
+- `model_hash`: caller-supplied; format `sha256:<64 hex chars>` enforced at write time. v0.1 accepted any value matching the regex; v0.2 enforces a real fingerprint.
 
 ### manifest contract
 

--- a/python/tools/_baseline_decoder.py
+++ b/python/tools/_baseline_decoder.py
@@ -29,8 +29,7 @@ def decode_baseline(path: Path):
     `byte_start`, `byte_end`, `embedding`. `meta` is the manifest fields
     we need to rebuild (model, dim, chunker_version, model_hash).
 
-    Raises `SystemExit` if the file is not raw-encoded — see the
-    embeddings-section requirement in ADR 0006.
+    Raises `SystemExit` if the file is not raw-encoded.
     """
     db = nest.open(str(path))
     info = db.inspect()

--- a/python/tools/nest_build_corpus.py
+++ b/python/tools/nest_build_corpus.py
@@ -57,7 +57,7 @@ def _filter_and_dedupe(combined: pd.DataFrame) -> tuple[pd.DataFrame, int, int]:
 
 def _resolve_model_hash():
     """Compute the corpus' `model_hash` from the local sentence-transformers
-    snapshot. Refuses to write the legacy placeholder — see ADR 0008."""
+    snapshot. Refuses to write the legacy placeholder."""
     from model_fingerprint import (
         compute_model_fingerprint,
         fingerprint_to_model_hash,


### PR DESCRIPTION
## Summary

- Remove ADR / kdb/adr references from `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `SECURITY.md`, `doc/architecture.md`, `doc/changelog.md`, `.github/PULL_REQUEST_TEMPLATE.md`, `.github/ISSUE_TEMPLATE/feature_request.md`.
- Remove inline ADR pointers from docstrings in \`python/tools/nest_build_corpus.py\` and \`python/tools/_baseline_decoder.py\`.
- \`.gitignore\`: explicit \`kdb/\` plus \`kdb/adr/\` (kdb/ alone covers it; both kept for clarity).

## Test plan

- [x] No source code or runtime behavior changed; only docs, templates, and ignore patterns.
- [x] \`grep\` for \`kdb\`, \`kdb/adr\`, \`ADR\` in tracked files returns no remaining matches outside \`kdb/adr/\` itself (which is now ignored).
- [x] Python files compile (\`python -m py_compile\` on the two edited modules).