### PR TITLE
refactor arc.mmd v2 (layered TB) and lift conventions into CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@
 2. branch from `dev`: `git checkout -b feature/short-description`.
 3. keep each pr focused on one concern. small is better.
 4. add or update tests for the change. new behavior needs a new test.
-5. if the change alters architecture, module boundaries, data flow, or doc locations, update `doc/arc/arc.yaml` and `doc/arc/arc.md` in the same pr. keep both concise and pragmatic. do not add a second human architecture doc.
+5. if the change alters architecture, module boundaries, data flow, or doc locations, update the arc trio (`doc/arc/arc.md`, `doc/arc/arc.yaml`, `doc/arc/arc.mmd`) in the same pr. keep all three concise and pragmatic. do not add a second human architecture doc.
 6. run `./scripts/release_check.sh` locally before pushing. that script is the same gate ci runs on the pr.
 7. commit with a clear message in plain english. no conventional commits prefix.
 8. open a pr against `dev`. the maintainer squashes or rebases into `main` at release time.
@@ -31,6 +31,33 @@ pip install ruff sentence-transformers pandas zstandard pyarrow
 
 `dat/corpus_next.v1.nest` is tracked via git lfs. demo datasets under `dat/demo/` are local-only and gitignored; fetch them with the commands documented in `dat/demo/README.md`. without those datasets, runtime unit tests still pass.
 
+## conventions and writing style
+
+these conventions are not aesthetic preferences. they exist to keep the repo readable for humans, agents, and vector search at the same time. if you find yourself wanting to break one, open an issue first and explain why; do not silently deviate. the goal is gentle communal pressure to keep the codebase legible.
+
+### naming
+
+- top-level directories and most root tokens use **3-char codes** (`dat`, `doc`, `ref`). this keeps directory glyphs atomic, easy to scan at a glance, and consistent across the hoff research repos that follow the same pattern. rust workspace conventions (`crates/`, `target/`) and language defaults (`python/`, `scripts/`, `tests/`) are kept as-is so the project stays idiomatic to its stack.
+- multi-word documentation and asset names use **kebab-case in english** (`code-of-conduct.md`-style filenames, dataset folders, etc.).
+- source files follow the conventions of their language (`snake_case.rs`, `snake_case.py`).
+- when proposing renames or moves, list exact `mv` commands first, execute the move, fix every touched import, and run the test suite after.
+
+### writing style
+
+- write in **diataxis style**: separate tutorial, how-to, reference, and explanation. mixing them produces noise.
+- **all lowercase** in body text. acronyms used as words keep their canonical case (`CLI`, `BM25`, `HNSW`, `SIMD`, `MIT`).
+- **no emoji**, anywhere. **no em-dash** (`-`); use `,`, `;`, `.`, or a regular hyphen.
+- short paragraphs, direct voice, no marketing copy. commits explain the **why**; the diff already shows the what. no conventional-commits prefix.
+- every governance or architecture doc starts with a yaml frontmatter block (`project`, `audience`, `status`, `last-updated`, `domain`) so llm and vector tooling can resolve it semantically.
+
+### file hygiene
+
+human working memory holds four plus or minus one chunks at once (cowan, 2001). neural networks behave better the same way. a file that does not fit the mental window forces internal context switching and raises bug rates. this is the same principle ui designers apply to information density.
+
+- **operational target for new files: 220 lines.** aim here.
+- **hard limit: 333 lines.** above this, refactor along single-responsibility lines in the same pr.
+- **rust source carve-out: 300 lines** for `crates/**/src/**`. test files and the `crates/nest-format/tests/roundtrip.rs` carve-out are exempt.
+
 ## code style
 
 rust:
@@ -39,14 +66,14 @@ rust:
 - `cargo clippy --workspace --all-targets -- -D warnings` is a hard gate. suppress an individual lint with `#[allow(clippy::name)]` and a one-line justification, never globally.
 - every `unsafe` block needs a `// SAFETY:` comment naming the invariant the caller is relying on.
 - public items get a doc comment that explains the why, not the what. the name already says what.
-- files in `crates/**/src/**` cap at 300 lines. test files are exempt.
+- file hygiene as above: 300 lines for `crates/**/src/**`.
 
 python:
 
 - target `py312`, line length 100. ruff config in `pyproject.toml`.
 - lints: `E F W I B UP SIM`. run `ruff check .` and `ruff format --check .`.
-- private helpers in `python/tools/` use the `_` prefix, e.g. `_baseline_decoder.py`.
-- same 333-line cap as rust.
+- private helpers in `python/tools/` use the `_` prefix (e.g. `_baseline_decoder.py`).
+- file hygiene as above: 220-line target, 333-line hard limit.
 
 format and runtime invariants:
 
@@ -68,7 +95,7 @@ python tests/test_search_text_model_hash.py
 
 - bugs and feature requests: [github issues](https://github.com/hoffresearch/nest/issues).
 - security vulns: do not open a public issue. email [brenner@hoffresearch.com](mailto:brenner@hoffresearch.com). target ack within 72 hours.
-- questions about the format: open a discussion, or read `doc/arc/arc.md` and `doc/arc/arc.yaml`.
+- questions about the format: open a discussion, or read `doc/arc/arc.md`, `doc/arc/arc.yaml`, and `doc/arc/arc.mmd`.
 
 bug reports should include the `.nest` `file_hash` and `content_hash` (from `nest stats <file>`), the runtime `simd_backend` (also in `nest stats`), the exact cli or python invocation, and the error output.
 

--- a/README.md
+++ b/README.md
@@ -34,109 +34,99 @@ put together: nobody outside the operator's machine has to be online, trusted, o
 python builds, rust serves. the .nest file is the contract between them. one writer pipeline produces a deterministic container; one mmap-backed runtime opens it and answers queries through a SIMD-dispatched search path. the cli and the python api are thin surfaces over the same runtime.
 
 ```mermaid
-graph LR
-    subgraph Gateway
-      CLI[nest cli]
-      PYAPI[python api]
+flowchart TB
+    classDef py   fill:#1e293b,stroke:#64748b,color:#e2e8f0
+    classDef rs   fill:#451a03,stroke:#b45309,color:#fed7aa
+    classDef ctr  fill:#064e3b,stroke:#10b981,color:#a7f3d0
+    classDef gate fill:#1f2937,stroke:#6b7280,color:#e5e7eb
+    classDef ref  fill:#1e1b4b,stroke:#6366f1,color:#c7d2fe
+
+    subgraph BUILD["python writer pipeline"]
+      direction LR
+      SRC["_corpus_sources.py<br/>dataset loaders"]:::py
+      FPR["model_fingerprint.py<br/>model_hash"]:::py
+      PIPE["builder.Pipeline<br/>chunk · sqlite cache · embed"]:::py
+      BLDFN["nest.build()<br/>python entry"]:::py
+      SRC --> PIPE
+      FPR --> PIPE
+      PIPE --> BLDFN
     end
 
-    subgraph Build
-      BLD[builder.py]
-      CHK[chunker]
-      EMB[embed_query.py]
-      FPR[model_fingerprint.py]
+    NEST[/".nest file · frozen v1 container<br/>required: chunks · embeddings · spans · provenance · contract<br/>optional: hnsw · bm25<br/>hashes: header · section · file · content"/]:::ctr
+
+    subgraph RUST["rust workspace"]
+      direction TB
+
+      subgraph PYBR["nest-python · pyo3 bridge"]
+        PYM["_nest.so · build · NestFile"]:::rs
+      end
+
+      subgraph FMT["nest-format · frozen v1"]
+        direction TB
+        WRT["writer<br/>deterministic emit"]:::rs
+        RDR["reader + validate<br/>parse · checksum"]:::rs
+        FMTI["layout · manifest · sections<br/>encoding zstd / fp16 / int8<br/>four hashes"]:::rs
+      end
+
+      subgraph RT["nest-runtime · mmap search engine"]
+        direction TB
+        MMP["mmap_file<br/>zero-copy open"]:::rs
+        SRCH["search<br/>orchestrator + mandatory exact rerank"]:::rs
+        SIMD["simd dispatch<br/>avx2 · neon · scalar"]:::rs
+        ANN["ann::HnswIndex · optional"]:::rs
+        BM25["bm25::Bm25Index · optional"]:::rs
+      end
+
+      subgraph CLIC["nest-cli · 8 clap subcommands"]
+        CLI["inspect · validate · stats · cite<br/>search · search-ann · search-text · benchmark"]:::rs
+      end
     end
 
-    subgraph Format
-      LAY[layout]
-      MAN[manifest]
-      SEC[sections]
-      ENC[encoding]
-      HSH[hashes]
+    EMB["embed_query.py<br/>query-time embedder<br/>spawned by search-text"]:::py
+    PYAPI["python/nest.py<br/>user-facing api"]:::py
+
+    subgraph QA["quality gates"]
+      direction LR
+      FX[("golden fixture<br/>byte-frozen")]:::gate
+      TST["cargo + python tests"]:::gate
+      GATE["release_check.sh"]:::gate
+      BASE[("measure/baseline.json")]:::gate
     end
 
-    subgraph Runtime
-      MMP[mmap_file]
-      SIMD[simd dispatch]
-      ANN[hnsw]
-      BM25[bm25]
-      SRCH[search]
-    end
+    ARC[["doc/arc trio<br/>arc.md · arc.yaml · arc.mmd<br/>updated by humans on arch changes"]]:::ref
 
-    subgraph Data
-      NEST[(.nest file)]
-      CORP[(corpus_next.v1.nest)]
-      BASE[(measure/baseline.json)]
-      FX[(golden fixture)]
-    end
+    %% build path
+    BLDFN -- "pyo3" --> PYM
+    PYM --> WRT
+    WRT == "emits" ==> NEST
 
-    subgraph Monitoring
-      TST[cargo + python tests]
-      GATE[release_check.sh]
-      ARC[doc/arc]
-    end
+    %% runtime open
+    NEST == "mmap" ==> MMP
+    MMP --> RDR
 
+    %% search orchestration
+    SRCH --> MMP
+    SRCH --> SIMD
+    SRCH -. "candidates" .-> ANN
+    SRCH -. "candidates" .-> BM25
+    ANN -. "rerank exact cosine" .-> SRCH
+    BM25 -. "rerank exact cosine" .-> SRCH
+
+    %% query interfaces
+    PYAPI --> PYM
+    PYM --> SRCH
     CLI --> SRCH
-    CLI --> MMP
-    PYAPI --> SRCH
-    PYAPI --> BLD
+    CLI -- "spawn" --> EMB
+    EMB -- "qvec + model_hash" --> CLI
+    CLI -. "validate model_hash<br/>vs manifest" .-> NEST
 
-    CHK --> BLD
-    EMB --> CLI
-    FPR --> BLD
-
-    BLD --> LAY
-    BLD --> MAN
-    BLD --> SEC
-    BLD --> ENC
-    BLD --> HSH
-    BLD --> NEST
-
-    NEST --> MMP
-    CORP --> MMP
-    MMP --> SIMD
-    MMP --> ANN
-    MMP --> BM25
-    SIMD --> SRCH
-    ANN --> SRCH
-    BM25 --> SRCH
-
+    %% quality
+    FX --> TST
     TST --> GATE
     GATE --> BASE
-    GATE --> ARC
-    FX --> TST
-
-    style Gateway fill:#0f172a,stroke:#334155,color:#e5e7eb
-    style Build fill:#0f172a,stroke:#334155,color:#e5e7eb
-    style Format fill:#0f172a,stroke:#334155,color:#e5e7eb
-    style Runtime fill:#0f172a,stroke:#334155,color:#e5e7eb
-    style Data fill:#0f172a,stroke:#334155,color:#e5e7eb
-    style Monitoring fill:#0f172a,stroke:#334155,color:#e5e7eb
-
-    style CLI fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style PYAPI fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style BLD fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style CHK fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style EMB fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style FPR fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style LAY fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style MAN fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style SEC fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style ENC fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style HSH fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style MMP fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style SIMD fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style ANN fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style BM25 fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style SRCH fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style NEST fill:#111827,stroke:#6b7280,color:#e5e7eb
-    style CORP fill:#111827,stroke:#6b7280,color:#e5e7eb
-    style BASE fill:#111827,stroke:#6b7280,color:#e5e7eb
-    style FX fill:#111827,stroke:#6b7280,color:#e5e7eb
-    style TST fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style GATE fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style ARC fill:#1f2937,stroke:#6b7280,color:#e5e7eb
 ```
+
+the diagram reads top to bottom in five layers: python writer pipeline, the `.nest` contract, the rust workspace (four crates), the query-time helpers and user-facing api, and the quality gates. the `.nest` file is the single artifact that crosses the language boundary. search.rs is the conductor on the rust side: it owns mandatory exact-cosine rerank for both hnsw and bm25 candidate paths. the doc/arc trio is updated by humans and agents on architecture-touching changes, not by ci.
 
 four crates plus a python tooling layer:
 
@@ -144,7 +134,7 @@ four crates plus a python tooling layer:
 - `nest-runtime` owns the mmap, the simd dispatcher, hnsw, bm25, and the search path with mandatory exact rerank.
 - `nest-cli` is a thin clap surface with eight subcommands.
 - `nest-python` is the pyo3 bridge that exposes the runtime to python.
-- `python/` holds the writer pipeline, chunker, model fingerprint, and the embedder used by `search-text`.
+- `python/` holds the writer pipeline, model fingerprint, and the query-time embedder used by `search-text`.
 
 full visual map: [doc/arc/arc.mmd](doc/arc/arc.mmd). human reference: [doc/arc/arc.md](doc/arc/arc.md). machine map: [doc/arc/arc.yaml](doc/arc/arc.yaml).
 

--- a/doc/arc/arc.mmd
+++ b/doc/arc/arc.mmd
@@ -1,110 +1,125 @@
 %% nest visual architecture reference
-%% visual companion to doc/arc/arc.md and doc/arc/arc.yaml
+%% companion to doc/arc/arc.md (human) and doc/arc/arc.yaml (machine).
+%%
+%% reading order (top to bottom):
+%%   1. python writer pipeline assembles chunks, embeddings, and the model fingerprint.
+%%   2. the .nest file is the frozen v1 contract that crosses the language boundary.
+%%   3. the rust workspace opens the file via mmap and serves queries.
+%%   4. cli and python api are thin client surfaces over the same runtime.
+%%   5. quality gates verify the pipeline; the arc trio is updated by humans on architecture changes.
 
-graph LR
-    subgraph Gateway
-      CLI[nest cli<br/>clap, 8 subcommands]
-      PYAPI[python api<br/>nest.open, nest.build]
+flowchart TB
+    classDef py   fill:#1e293b,stroke:#64748b,color:#e2e8f0
+    classDef rs   fill:#451a03,stroke:#b45309,color:#fed7aa
+    classDef ctr  fill:#064e3b,stroke:#10b981,color:#a7f3d0
+    classDef gate fill:#1f2937,stroke:#6b7280,color:#e5e7eb
+    classDef ref  fill:#1e1b4b,stroke:#6366f1,color:#c7d2fe
+
+    %% ============================================================
+    %% layer 1 · python writer pipeline
+    %% ============================================================
+    subgraph BUILD["python writer pipeline"]
+      direction LR
+      SRC["_corpus_sources.py<br/>dataset loaders"]:::py
+      FPR["model_fingerprint.py<br/>model_hash"]:::py
+      PIPE["builder.Pipeline<br/>chunk · sqlite cache · embed"]:::py
+      BLDFN["nest.build()<br/>python entry"]:::py
+      SRC --> PIPE
+      FPR --> PIPE
+      PIPE --> BLDFN
     end
 
-    subgraph Build
-      BLD[builder.py<br/>pipeline]
-      CHK[chunker]
-      EMB[embed_query.py]
-      FPR[model_fingerprint.py]
+    %% ============================================================
+    %% layer 2 · the contract (the file)
+    %% ============================================================
+    NEST[/".nest file · frozen v1 container<br/>required: chunks · embeddings · spans · provenance · contract<br/>optional: hnsw · bm25<br/>hashes: header · section · file · content"/]:::ctr
+
+    %% ============================================================
+    %% layer 3 · rust workspace (4 crates)
+    %% ============================================================
+    subgraph RUST["rust workspace"]
+      direction TB
+
+      subgraph PYBR["nest-python · pyo3 bridge"]
+        PYM["_nest.so · build · NestFile"]:::rs
+      end
+
+      subgraph FMT["nest-format · frozen v1"]
+        direction TB
+        WRT["writer<br/>deterministic emit"]:::rs
+        RDR["reader + validate<br/>parse · checksum"]:::rs
+        FMTI["layout · manifest · sections<br/>encoding zstd / fp16 / int8<br/>four hashes"]:::rs
+      end
+
+      subgraph RT["nest-runtime · mmap search engine"]
+        direction TB
+        MMP["mmap_file<br/>zero-copy open"]:::rs
+        SRCH["search<br/>orchestrator + mandatory exact rerank"]:::rs
+        SIMD["simd dispatch<br/>avx2 · neon · scalar"]:::rs
+        ANN["ann::HnswIndex · optional"]:::rs
+        BM25["bm25::Bm25Index · optional"]:::rs
+      end
+
+      subgraph CLIC["nest-cli · 8 clap subcommands"]
+        CLI["inspect · validate · stats · cite<br/>search · search-ann · search-text · benchmark"]:::rs
+      end
     end
 
-    subgraph Format
-      LAY[layout<br/>header, footer, sections]
-      MAN[manifest<br/>canonical json]
-      SEC[sections<br/>chunks, spans, contract]
-      ENC[encoding<br/>zstd, float16, int8]
-      HSH[hashes<br/>file, content, section]
+    %% ============================================================
+    %% layer 4 · query-time helpers
+    %% ============================================================
+    EMB["embed_query.py<br/>query-time embedder<br/>spawned by search-text"]:::py
+    PYAPI["python/nest.py<br/>user-facing api"]:::py
+
+    %% ============================================================
+    %% layer 5 · quality gates and references
+    %% ============================================================
+    subgraph QA["quality gates"]
+      direction LR
+      FX[("golden fixture<br/>byte-frozen")]:::gate
+      TST["cargo + python tests"]:::gate
+      GATE["release_check.sh"]:::gate
+      BASE[("measure/baseline.json")]:::gate
     end
 
-    subgraph Runtime
-      MMP[mmap_file<br/>zero-copy open]
-      SIMD[simd<br/>avx2, neon, scalar]
-      ANN[hnsw index]
-      BM25[bm25 index]
-      SRCH[search<br/>exact, ann, hybrid]
-    end
+    ARC[["doc/arc trio<br/>arc.md · arc.yaml · arc.mmd<br/>updated by humans on arch changes"]]:::ref
 
-    subgraph Data
-      NEST[(.nest file)]
-      CORP[(dat/corpus_next.v1.nest)]
-      BASE[(dat/measure/baseline.json)]
-      FX[(golden fixture)]
-    end
+    %% ============================================================
+    %% edges · build path
+    %% ============================================================
+    BLDFN -- "pyo3" --> PYM
+    PYM --> WRT
+    WRT == "emits" ==> NEST
 
-    subgraph Monitoring
-      TST[cargo test + python tests]
-      GATE[scripts/release_check.sh]
-      ARC[doc/arc]
-    end
+    %% ============================================================
+    %% edges · runtime open
+    %% ============================================================
+    NEST == "mmap" ==> MMP
+    MMP --> RDR
 
+    %% ============================================================
+    %% edges · search orchestration (search is the conductor)
+    %% ============================================================
+    SRCH --> MMP
+    SRCH --> SIMD
+    SRCH -. "candidates" .-> ANN
+    SRCH -. "candidates" .-> BM25
+    ANN -. "rerank exact cosine" .-> SRCH
+    BM25 -. "rerank exact cosine" .-> SRCH
+
+    %% ============================================================
+    %% edges · query interfaces
+    %% ============================================================
+    PYAPI --> PYM
+    PYM --> SRCH
     CLI --> SRCH
-    CLI --> MMP
-    PYAPI --> SRCH
-    PYAPI --> BLD
+    CLI -- "spawn" --> EMB
+    EMB -- "qvec + model_hash" --> CLI
+    CLI -. "validate model_hash<br/>vs manifest" .-> NEST
 
-    CHK --> BLD
-    EMB --> CLI
-    FPR --> BLD
-
-    BLD --> LAY
-    BLD --> MAN
-    BLD --> SEC
-    BLD --> ENC
-    BLD --> HSH
-    BLD --> NEST
-
-    NEST --> MMP
-    CORP --> MMP
-    MMP --> SIMD
-    MMP --> ANN
-    MMP --> BM25
-    SIMD --> SRCH
-    ANN --> SRCH
-    BM25 --> SRCH
-
+    %% ============================================================
+    %% edges · quality
+    %% ============================================================
+    FX --> TST
     TST --> GATE
     GATE --> BASE
-    GATE --> ARC
-    FX --> TST
-
-    style Gateway fill:#0f172a,stroke:#334155,color:#e5e7eb
-    style Build fill:#0f172a,stroke:#334155,color:#e5e7eb
-    style Format fill:#0f172a,stroke:#334155,color:#e5e7eb
-    style Runtime fill:#0f172a,stroke:#334155,color:#e5e7eb
-    style Data fill:#0f172a,stroke:#334155,color:#e5e7eb
-    style Monitoring fill:#0f172a,stroke:#334155,color:#e5e7eb
-
-    style CLI fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style PYAPI fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-
-    style BLD fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style CHK fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style EMB fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style FPR fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-
-    style LAY fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style MAN fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style SEC fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style ENC fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style HSH fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-
-    style MMP fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style SIMD fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style ANN fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style BM25 fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style SRCH fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-
-    style NEST fill:#111827,stroke:#6b7280,color:#e5e7eb
-    style CORP fill:#111827,stroke:#6b7280,color:#e5e7eb
-    style BASE fill:#111827,stroke:#6b7280,color:#e5e7eb
-    style FX fill:#111827,stroke:#6b7280,color:#e5e7eb
-
-    style TST fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style GATE fill:#1f2937,stroke:#6b7280,color:#e5e7eb
-    style ARC fill:#1f2937,stroke:#6b7280,color:#e5e7eb


### PR DESCRIPTION
## summary

follows up on pr #23 with two corrections.

### arc.mmd v2 (and the same diagram in README)

honest self-critique of the v1 diagram, applied:

- removed `chunker` as a separate node; it is internal to `builder.Pipeline`.
- moved `embed_query.py` out of the build subgraph; it runs at query time, spawned by `search-text`.
- promoted the four crates (`nest-format`, `nest-runtime`, `nest-cli`, `nest-python`) to first-class subgraphs inside a `rust workspace` container.
- collapsed `.nest file` and `corpus_next.v1.nest` into one contract node.
- removed the false `release_check.sh -> doc/arc` edge; the arc trio is updated by humans on architecture-touching changes, not by ci.
- added the exact-cosine rerank loop from `ann` and `bm25` back into `search.rs` (the key score-contract invariant of the runtime).
- added the model_hash validation dashed edge from `nest-cli` against the manifest inside `.nest` (the search-text invariant).
- switched layout to TB (top-down) in five layers so the diagram reads python -> file -> rust workspace -> query interfaces -> quality gates.

### CONTRIBUTING.md

new conventions and writing style section that explains, with reasons, the conventions the repo wants community to follow:

- naming: 3-char top-level tokens (`dat`, `doc`, `ref`), kebab-case for docs and assets, idiomatic per-language source naming.
- writing style: diataxis, all lowercase, no emoji, no em-dash, no marketing copy, yaml frontmatter on governance docs.
- file hygiene: 220-line operational target, 333-line hard limit, 300-line carve-out for rust source, with the cowan-2001 working-memory reason stated so the rule is teachable rather than dogmatic.

also reconciled the previous inconsistency (python said "same 333-line cap as rust" while rust is 300) and pointed all architecture-touching prs at the arc trio (arc.md + arc.yaml + arc.mmd).

CODE_OF_CONDUCT.md and README.md were inspected and left unchanged: the former is already in project voice (lowercase, minimal, no emoji), the latter is a product overview that should not carry governance noise.

## test plan

- [x] open README in github web ui and verify the new mermaid renders cleanly
- [x] open doc/arc/arc.mmd in a mermaid viewer and verify the TB layout reads python -> file -> rust -> interfaces -> gates
- [x] confirm CONTRIBUTING.md displays the new conventions section without rendering glitches
- [x] sanity check: no emoji, no em-dash, no file over 333 lines