### PR TITLE
replace architecture flowchart with a sequence diagram

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,7 @@ these are documented honest limitations of the current code, not bugs to silentl
 - `README.md`: project overview, install, CLI summary, presets, v0.2 highlights, embedded mermaid system view.
 - `doc/arc/arc.md`: single human architecture inventory and runtime contract summary.
 - `doc/arc/arc.yaml`: machine-readable architecture map for agents and tooling.
-- `doc/arc/arc.mmd`: visual architecture map (mermaid) covering gateway, build, format, runtime, data, and monitoring.
+- `doc/arc/arc.mmd`: mermaid sequence diagram of the build and query flows.
 - `doc/usage.md`: 10-section how-to for the 8 commands, presets, offline mode, citations.
 - `doc/changelog.md`: v0.1.0 and v0.2.0 deltas.
 - `dat/demo/README.md`: what each upstream PT-BR dataset is and how to rebuild the unified corpus.

--- a/README.md
+++ b/README.md
@@ -34,55 +34,32 @@ put together: nobody outside the operator's machine has to be online, trusted, o
 python builds, rust serves. the .nest file is the contract between them. one writer pipeline produces a deterministic container; one mmap-backed runtime opens it and answers queries through a SIMD-dispatched search path. the cli and the python api are thin surfaces over the same runtime.
 
 ```mermaid
-flowchart LR
-    classDef py   fill:#1e293b,stroke:#475569,color:#e2e8f0
-    classDef rs   fill:#3f1d05,stroke:#a45a09,color:#fcd9b6
-    classDef ctr  fill:#064e3b,stroke:#10b981,color:#a7f3d0,stroke-width:3px
-    classDef gate fill:#1f2937,stroke:#6b7280,color:#cbd5e1
+sequenceDiagram
+    autonumber
+    participant B as builder.py
+    participant F as nest-format
+    participant N as .nest file
+    participant R as nest-runtime
+    participant E as embed_query.py
+    participant Q as nest cli / api
 
-    subgraph BUILD["python build pipeline"]
-      direction TB
-      FPR["model_fingerprint<br/>model_hash"]:::py
-      PIPE["builder.Pipeline<br/>chunk · embed · sqlite cache"]:::py
-      FPR --> PIPE
-    end
+    note over B,N: build · offline · reproducible
+    B->>B: chunk + embed + model_hash
+    B->>F: nest.build(chunks, model_hash)
+    F->>N: deterministic emit + four hashes
 
-    NEST(["<b>.nest file</b><br/>frozen v1 container<br/>chunks · embeddings · spans · provenance · contract<br/>optional hnsw · bm25<br/>hashes: header · section · file · content"]):::ctr
-
-    subgraph RUST["rust workspace · 4 crates"]
-      direction TB
-      FMT["nest-format<br/>writer · reader · encodings · hashes"]:::rs
-      RT["nest-runtime<br/>mmap · simd avx2 / neon / scalar<br/>hnsw · bm25 · mandatory exact rerank"]:::rs
-      CLI["nest-cli<br/>8 clap subcommands"]:::rs
-      PYB["nest-python<br/>pyo3 bridge"]:::rs
-      FMT --- RT
-      RT --- CLI
-      RT --- PYB
-    end
-
-    subgraph QRY["query interfaces"]
-      direction TB
-      PYAPI["python/nest.py<br/>user-facing api"]:::py
-      EMB["embed_query.py<br/>spawned by search-text"]:::py
-    end
-
-    subgraph QA["quality gates"]
-      direction TB
-      TST["cargo + python tests"]:::gate
-      GATE["release_check.sh"]:::gate
-      BASE["measure/baseline.json"]:::gate
-      TST --> GATE
-      GATE --> BASE
-    end
-
-    PIPE  ==> NEST
-    NEST  ==> FMT
-    NEST  ==> RT
-    PYAPI --> PYB
-    CLI   -.-> EMB
+    note over R,Q: query · offline · mmap
+    Q->>E: search-text spawns embedder
+    E-->>Q: query vector + model_hash
+    Q->>R: search(vector)
+    R->>N: mmap open + validate hashes
+    R->>R: model_hash vs manifest
+    R->>R: hnsw / bm25 candidates
+    R->>R: mandatory exact cosine rerank
+    R-->>Q: hits + nest://content_hash/chunk_id
 ```
 
-the diagram reads left to right in four bands plus a quality column. python builds, the `.nest` file is the contract, the rust workspace (four crates) opens it and serves queries, and the query interfaces sit on the right. exact-cosine rerank is mandatory inside `nest-runtime` for both hnsw and bm25 candidate paths.
+the sequence traces the two flows that define nest. build (python, offline, reproducible) chunks, embeds, fingerprints the model, and writes a deterministic `.nest` file with four hashes. query (rust, offline, mmap) opens the file, validates the embedder's `model_hash` against the manifest, gathers hnsw or bm25 candidates, and reranks them with exact cosine before returning citations. the `.nest` file is the only artifact that crosses between python and rust.
 
 four crates plus a python tooling layer:
 
@@ -212,7 +189,7 @@ with `reproducible=True` (the script default) two operators get byte-identical `
 - `dat/demo/README.md` for what each upstream dataset is and how to rebuild the corpus
 - `doc/arc/arc.md` for architecture, binary layout, API surface, errors, and versioning
 - `doc/arc/arc.yaml` for the machine-readable architecture map used by agents and tooling
-- `doc/arc/arc.mmd` for the mermaid visual map of gateway, build, format, runtime, data, and monitoring
+- `doc/arc/arc.mmd` for the mermaid sequence diagram of the build and query flows
 - `doc/usage.md` for the eight commands, presets, offline mode, citations
 - `doc/changelog.md` for v0.1 to v0.2 deltas
 

--- a/doc/arc/arc.md
+++ b/doc/arc/arc.md
@@ -181,7 +181,7 @@ the trio is kept in sync: arc.md (human), arc.yaml (machine), arc.mmd (visual). 
 
 - doc/arc/arc.md | markdown doc | single human architecture inventory and contract reference for the repo.
 - doc/arc/arc.yaml | yaml doc | machine-readable architecture map for agents, llms, and maintenance workflows.
-- doc/arc/arc.mmd | mermaid doc | visual architecture map covering gateway, build, format, runtime, data, and monitoring.
+- doc/arc/arc.mmd | mermaid doc | sequence diagram of the build and query flows.
 - dat | data dir | top-level home for the demo sources, baseline corpus, and measure outputs.
 - doc/changelog.md | markdown doc | release deltas, compatibility notes, and test-surface growth between v0.1 and v0.2.
 - doc/usage.md | markdown doc | operator-facing usage guide for build, validate, stats, inspect, search, benchmark, and citations.

--- a/doc/arc/arc.mmd
+++ b/doc/arc/arc.mmd
@@ -1,57 +1,36 @@
 %% nest visual architecture reference
 %% companion to doc/arc/arc.md (human) and doc/arc/arc.yaml (machine).
 %%
-%% design notes:
-%%   - LR direction with single-level subgraphs only. nested subgraphs break
-%%     mermaid auto-layout on github when cross-cluster edges multiply.
-%%   - one dominant flow: python build -> the .nest contract -> rust workspace
-%%     -> query interfaces. quality gates are a separate column.
-%%   - module internals are not shown here on purpose. the file inventory in
-%%     arc.md and arc.yaml is the authoritative breakdown.
+%% design note:
+%%   this is a sequenceDiagram, not a flowchart with subgraphs. structured
+%%   diagram types lay out deterministically and render cleanly on github;
+%%   subgraph flowcharts with cross-cluster edges do not. the file inventory
+%%   in arc.md and arc.yaml is the authoritative module breakdown.
+%%
+%%   it traces the two flows that define nest: build (python writes the file)
+%%   and query (rust serves from the file). the .nest file is the only
+%%   artifact that crosses the language boundary.
 
-flowchart LR
-    classDef py   fill:#1e293b,stroke:#475569,color:#e2e8f0
-    classDef rs   fill:#3f1d05,stroke:#a45a09,color:#fcd9b6
-    classDef ctr  fill:#064e3b,stroke:#10b981,color:#a7f3d0,stroke-width:3px
-    classDef gate fill:#1f2937,stroke:#6b7280,color:#cbd5e1
+sequenceDiagram
+    autonumber
+    participant B as builder.py
+    participant F as nest-format
+    participant N as .nest file
+    participant R as nest-runtime
+    participant E as embed_query.py
+    participant Q as nest cli / api
 
-    subgraph BUILD["python build pipeline"]
-      direction TB
-      FPR["model_fingerprint<br/>model_hash"]:::py
-      PIPE["builder.Pipeline<br/>chunk · embed · sqlite cache"]:::py
-      FPR --> PIPE
-    end
+    note over B,N: build · offline · reproducible
+    B->>B: chunk + embed + model_hash
+    B->>F: nest.build(chunks, model_hash)
+    F->>N: deterministic emit + four hashes
 
-    NEST(["<b>.nest file</b><br/>frozen v1 container<br/>chunks · embeddings · spans · provenance · contract<br/>optional hnsw · bm25<br/>hashes: header · section · file · content"]):::ctr
-
-    subgraph RUST["rust workspace · 4 crates"]
-      direction TB
-      FMT["nest-format<br/>writer · reader · encodings · hashes"]:::rs
-      RT["nest-runtime<br/>mmap · simd avx2 / neon / scalar<br/>hnsw · bm25 · mandatory exact rerank"]:::rs
-      CLI["nest-cli<br/>8 clap subcommands"]:::rs
-      PYB["nest-python<br/>pyo3 bridge"]:::rs
-      FMT --- RT
-      RT --- CLI
-      RT --- PYB
-    end
-
-    subgraph QRY["query interfaces"]
-      direction TB
-      PYAPI["python/nest.py<br/>user-facing api"]:::py
-      EMB["embed_query.py<br/>spawned by search-text"]:::py
-    end
-
-    subgraph QA["quality gates"]
-      direction TB
-      TST["cargo + python tests"]:::gate
-      GATE["release_check.sh"]:::gate
-      BASE["measure/baseline.json"]:::gate
-      TST --> GATE
-      GATE --> BASE
-    end
-
-    PIPE  ==> NEST
-    NEST  ==> FMT
-    NEST  ==> RT
-    PYAPI --> PYB
-    CLI   -.-> EMB
+    note over R,Q: query · offline · mmap
+    Q->>E: search-text spawns embedder
+    E-->>Q: query vector + model_hash
+    Q->>R: search(vector)
+    R->>N: mmap open + validate hashes
+    R->>R: model_hash vs manifest
+    R->>R: hnsw / bm25 candidates
+    R->>R: mandatory exact cosine rerank
+    R-->>Q: hits + nest://content_hash/chunk_id

--- a/doc/arc/arc.yaml
+++ b/doc/arc/arc.yaml
@@ -166,7 +166,7 @@ inventory:
   data_docs_python_scripts_tests:
     - {path: "doc/arc/arc.md", kind: markdown-doc, purpose: "single human architecture inventory and contract reference", links: ["doc/arc/arc.yaml", "doc/arc/arc.mmd"]}
     - {path: "doc/arc/arc.yaml", kind: yaml-doc, purpose: "machine-readable architecture map for agents and tooling", links: ["doc/arc/arc.md", "doc/arc/arc.mmd"]}
-    - {path: "doc/arc/arc.mmd", kind: mermaid-doc, purpose: "visual architecture map covering gateway, build, format, runtime, data, and monitoring", links: ["doc/arc/arc.md", "doc/arc/arc.yaml"]}
+    - {path: "doc/arc/arc.mmd", kind: mermaid-doc, purpose: "sequence diagram of the build and query flows", links: ["doc/arc/arc.md", "doc/arc/arc.yaml"]}
     - {path: "dat", kind: directory, purpose: "data root for corpora and demo sources", links: ["dat/demo/README.md"]}
     - {path: "doc", kind: directory, purpose: "top-level documentation root", links: ["doc/arc/arc.md", "doc/arc/arc.yaml", "doc/arc/arc.mmd", "doc/usage.md", "doc/changelog.md"]}
     - {path: "python", kind: directory, purpose: "python wrapper and tooling root", links: ["python/nest.py", "python/builder.py", "python/tools"]}


### PR DESCRIPTION
## summary

the three previous flowchart attempts (pr #23 v1, pr #25 v2, pr #27 v3) all rendered badly on github. the root cause was the diagram type, not the styling: **flowcharts with subgraphs and cross-cluster edges defeat mermaid's auto-layout**, scattering clusters and crossing edges into noise.

structured diagram types (sequence, er, state) lay out deterministically and render cleanly, every time. nest has two flows that define it, so a `sequenceDiagram` is the right fit:

- **build** (python, offline, reproducible): chunk, embed, fingerprint the model, write a deterministic `.nest` with four hashes.
- **query** (rust, offline, mmap): open the file, validate the embedder `model_hash` against the manifest, gather hnsw/bm25 candidates, rerank with exact cosine, return `nest://content_hash/chunk_id` citations.

the `.nest` file is the only artifact that crosses the python/rust boundary, which a sequence diagram makes literal (it is a participant both sides talk to).

### changed

- `doc/arc/arc.mmd`: flowchart -> sequenceDiagram.
- `README.md`: same diagram + rewritten caption describing the two flows.
- `doc/arc/arc.md`, `doc/arc/arc.yaml`, `AGENTS.md`: pointer descriptions updated from "visual map of gateway/build/..." to "sequence diagram of the build and query flows".

## test plan

- [x] open README on github web ui and confirm the sequence diagram renders clean with no pan/zoom chaos
- [x] confirm autonumber and the two note bands (build / query) display correctly
- [x] verify arc.mmd renders identically in a mermaid live editor