### PR TITLE
chore(phi): defense-in-depth PHI safety (gitignore + pre-commit + threat model)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,18 @@ dat/measure/*.nest-*
 # Local symlink to external hoff database (not part of this repo)
 dat/hoff.db
 
+# PHI / clinical artifacts — NEVER commit. clinical data lives OUTSIDE this repo
+# (e.g. /Volumes/<redacted>/dat/psy/work, which is NOT under any git repo). these
+# patterns are defense-in-depth so a misdirected --out into the repo tree can
+# never be staged or pushed by any auto-committer — INCLUDING a `git add -A`
+# from a `--no-verify` commit, which still honors .gitignore.
+#
+# Ignore ALL .nest by default (a PHI export with any name, not just cohort_*),
+# then negate ONLY the three sanctioned PUBLIC, non-PHI corpora that ARE tracked.
+*.nest
+*.sidecar.jsonl
+**/pairs/
+!dat/corpus_next.v1.nest
+!crates/nest-format/tests/fixtures/golden_v1_minimal.nest
+!dat/measure/fakerecogna_exact.nest
+

--- a/doc/phi-safety.md
+++ b/doc/phi-safety.md
@@ -1,0 +1,73 @@
+# PHI safety — threat model and controls
+
+This repo is developed against a private clinical dataset (psychotherapy session
+notes). **No PHI may ever be committed or pushed.** The remote is
+`github.com/hoffresearch/nest`. This document records the threat model and the
+defense-in-depth controls, so the controls are auditable and re-installable.
+
+## Threat model
+
+The development environment performs **environment-level auto-commit/push** of the
+working tree (it is not a repo hook — the only `.git/hooks` present are benign
+git-lfs delegators). The risk is: a PHI artifact lands inside the repo working
+tree and an auto-committer stages + pushes it to GitHub before a human notices.
+
+## Controls (defense in depth)
+
+**1. Physical separation — the root guarantee.**
+Clinical data lives at `/Volumes/<redacted>/dat/psy/work`, which is **not under any git
+repository** (no `.git` in any parent up to the `/Volumes` mount). The repo is at
+`/Volumes/<redacted>/dev/nest`, a sibling tree. An auto-committer operating on the nest
+repo therefore *cannot* see, stage, or push the clinical files at all. All build
+tools write their `.nest` / sidecar outputs to `dat/psy/work`, outside the repo.
+
+Verify:
+```sh
+git -C /Volumes/<redacted>/dat/psy/work rev-parse --show-toplevel
+# expected: fatal: not a git repository (or any parent up to mount point /Volumes)
+```
+
+**2. `.gitignore` catch-all — survives `--no-verify`.**
+`.gitignore` ignores **all** `*.nest`, `*.sidecar.jsonl`, and `**/pairs/` by
+default, negating only the three sanctioned PUBLIC, non-PHI corpora that are
+tracked (`dat/corpus_next.v1.nest`, `dat/measure/fakerecogna_exact.nest`,
+`crates/nest-format/tests/fixtures/golden_v1_minimal.nest`). A PHI export with
+*any* filename is ignored, so even `git add -A` from a `git commit --no-verify`
+(which still honors `.gitignore`) cannot stage it. This is the layer that holds
+when hooks are bypassed.
+
+**3. Active `pre-commit` gate — catches force-adds.**
+`scripts/pre-commit` (version-tracked) aborts any commit that stages a `.nest` /
+`.sidecar.jsonl` / `pairs/` artifact not on its explicit allow-list — catching a
+`git add -f` that bypasses `.gitignore`. It coexists with the git-lfs hooks (LFS
+uses post-commit/pre-push, not pre-commit). It is **not** wired via
+`core.hooksPath` (that would disable the LFS hooks).
+
+Install on a fresh clone (`.git/hooks` is not version-tracked):
+```sh
+cp scripts/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
+```
+
+## Verifying the controls
+
+```sh
+# layer 2: an arbitrarily-named PHI .nest is ignored
+touch dat/measure/zzz_fake_phi.nest
+git check-ignore -v dat/measure/zzz_fake_phi.nest   # -> .gitignore:*.nest  (ignored)
+git status --short | grep zzz                        # -> (no output: invisible to add -A)
+
+# layer 3: pre-commit blocks even a forced stage
+git add -f dat/measure/zzz_fake_phi.nest
+.git/hooks/pre-commit                                # -> BLOCKED, exit 1
+git reset -q dat/measure/zzz_fake_phi.nest && trash dat/measure/zzz_fake_phi.nest
+
+# the three public corpora remain trackable (negations win)
+git check-ignore -q dat/corpus_next.v1.nest && echo IGNORED-BAD || echo ok-trackable
+```
+
+## Audit (as of this writing)
+
+- PHI directory is outside any git repo: confirmed.
+- Tracked `.nest` files: only the three public corpora above. No PHI tracked.
+- Working tree: clean.
+- All three controls verified end-to-end.

--- a/doc/phi-safety.md
+++ b/doc/phi-safety.md
@@ -9,8 +9,18 @@ defense-in-depth controls, so the controls are auditable and re-installable.
 
 The development environment performs **environment-level auto-commit/push** of the
 working tree (it is not a repo hook — the only `.git/hooks` present are benign
-git-lfs delegators). The risk is: a PHI artifact lands inside the repo working
-tree and an auto-committer stages + pushes it to GitHub before a human notices.
+git-lfs delegators). The primary risk is: a PHI artifact lands inside the repo
+working tree and an auto-committer stages + pushes it to GitHub before a human
+notices.
+
+A second vector is **scratch / measurement artifacts**: tools that read PHI
+(cohort builders, the relevance ruler, dedup audits) can write cleartext
+intermediates — sidecars, per-pair note files, temp `.nest` — to `/tmp` or the
+work dir. `/tmp` is world-traversable (mode `1777`) and cleaned only by a periodic
+job (files older than ~3 days), so PHI written there is readable by any local user
+until then. Separately, these controls protect the *git repo*, not the *disk*:
+`/Volumes/<redacted>` is an **unencrypted** external APFS volume, so physical loss/theft
+or remounting it on another machine bypasses Unix permissions entirely.
 
 ## Controls (defense in depth)
 
@@ -48,6 +58,14 @@ Install on a fresh clone (`.git/hooks` is not version-tracked):
 cp scripts/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
 ```
 
+**4. Scratch hygiene — PHI never in `/tmp`, work dir locked down.**
+All PHI intermediates go under `/Volumes/<redacted>/dat/psy/work` (mode `700`), **never
+`/tmp`** (world-traversable). PHI files there are mode `600`. Measurement
+artifacts (per-pair note files, sidecars, cohort `.nest`) are EPHEMERAL: deleted
+(`trash`) immediately after the analysis that needs them; only non-PHI derived
+results (counts, AUC, the numbers committed to the plan) persist. A tool that
+reads note text writes its output to the work dir and cleans up on completion.
+
 ## Verifying the controls
 
 ```sh
@@ -65,9 +83,28 @@ git reset -q dat/measure/zzz_fake_phi.nest && trash dat/measure/zzz_fake_phi.nes
 git check-ignore -q dat/corpus_next.v1.nest && echo IGNORED-BAD || echo ok-trackable
 ```
 
+## Residual risks (not closed by these controls)
+
+These controls protect the **git repository**. Two PHI vectors remain — owned by
+the operator, not the code:
+
+- **Disk encryption (open).** `/Volumes/<redacted>` is an unencrypted external USB APFS
+  volume (`diskutil info /Volumes/<redacted>` → `Encrypted: No`). `chmod 600` stops other
+  users on the *running* system, not physical theft or remounting the disk
+  elsewhere as admin. **Mitigation: enable APFS / FileVault encryption on the
+  volume.** This is the one link `chmod` cannot close.
+- **Backup / sync (verified clear, re-check before enabling any).** At audit time:
+  **no Time Machine destination** (`tmutil destinationinfo` → none) and **no
+  third-party cloud-sync daemon** (Dropbox/Drive/OneDrive) over the volume; the
+  system iCloud `bird` daemon does not sync arbitrary external volumes. A backup
+  tool, once enabled, copies PHI regardless of file mode — exclude `/Volumes/<redacted>`
+  if one is ever turned on.
+
 ## Audit (as of this writing)
 
 - PHI directory is outside any git repo: confirmed.
 - Tracked `.nest` files: only the three public corpora above. No PHI tracked.
 - Working tree: clean.
-- All three controls verified end-to-end.
+- All three repo controls verified end-to-end.
+- Work dir `dat/psy/work` is mode `700`, PHI files `600`; `/tmp` cleared of PHI.
+- Volume is unencrypted (residual risk above); no Time Machine, no cloud sync.

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -2,13 +2,16 @@
 # scripts/pre-commit — defense-in-depth against committing PHI / data artifacts.
 #
 # Clinical data MUST live OUTSIDE this repo (e.g. /Volumes/<redacted>/dat/psy/work).
-# The .gitignore already skips *.sidecar.jsonl / cohort_*.nest / **/pairs/, but
-# this hook is the stronger backstop: it ABORTS any commit that stages a data
-# artifact (.nest / .sidecar.jsonl / a file under pairs/) that is not on the
-# explicit allow-list of sanctioned public corpora below.
+# The .gitignore already ignores *.nest / *.sidecar.jsonl / **/pairs/ (a catch-all
+# that negates only the sanctioned public corpora), but this hook is the stronger
+# backstop: it ABORTS any commit that stages a data artifact (.nest /
+# .sidecar.jsonl / a file under pairs/) that is not on the explicit allow-list of
+# sanctioned public corpora below — catching a `git add -f` that bypasses gitignore.
 #
-# Enable once per clone (it lives outside .git/hooks so it is version-tracked):
-#   git config core.hooksPath scripts && git lfs install --local
+# Install once per clone (it lives outside .git/hooks so it is version-tracked).
+# Copy it in rather than `core.hooksPath scripts`, which would DISABLE the git-lfs
+# hooks (LFS uses post-commit/pre-push, not pre-commit, so the two coexist):
+#   cp scripts/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
 #
 set -eu
 

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,37 @@
+#!/bin/sh
+# scripts/pre-commit — defense-in-depth against committing PHI / data artifacts.
+#
+# Clinical data MUST live OUTSIDE this repo (e.g. /Volumes/<redacted>/dat/psy/work).
+# The .gitignore already skips *.sidecar.jsonl / cohort_*.nest / **/pairs/, but
+# this hook is the stronger backstop: it ABORTS any commit that stages a data
+# artifact (.nest / .sidecar.jsonl / a file under pairs/) that is not on the
+# explicit allow-list of sanctioned public corpora below.
+#
+# Enable once per clone (it lives outside .git/hooks so it is version-tracked):
+#   git config core.hooksPath scripts && git lfs install --local
+#
+set -eu
+
+# Explicit allow-list: the only tracked data artifacts permitted. These are
+# public, non-PHI benchmark/demo/fixture files. Anything else (any new .nest,
+# any cohort_*, any sidecar, anything under pairs/) is blocked.
+ALLOW='^(dat/corpus_next\.v1\.nest|dat/measure/fakerecogna_exact\.nest|crates/nest-format/tests/fixtures/golden_v1_minimal\.nest)$'
+
+staged=$(git diff --cached --name-only --diff-filter=ACM)
+[ -n "$staged" ] || exit 0
+
+violations=$(printf '%s\n' "$staged" | grep -E \
+  -e '(^|/)cohort_[^/]*\.nest$' \
+  -e '\.sidecar\.jsonl$' \
+  -e '(^|/)pairs/' \
+  -e '\.nest$' \
+  | grep -Ev "$ALLOW" || true)
+
+if [ -n "$violations" ]; then
+  printf >&2 '\nBLOCKED: data / PHI artifact(s) staged for commit:\n'
+  printf >&2 '  %s\n' $violations
+  printf >&2 '\nClinical data must live OUTSIDE this repo (e.g. /Volumes/<redacted>/dat/psy/work).\n'
+  printf >&2 'If a file is legitimately tracked, add it to ALLOW in scripts/pre-commit.\n\n'
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
**PR-C of 3** (split: C=phi-safety / A=0x17 feature / B=build dedup). Base `research/nest-genome-v2` so the diff is purely the PHI controls (vs `main`, which is 53 commits behind, .gitignore would drag unrelated prior changes).

Clinical data lives OUTSIDE this repo (not under any git repo). Three layered controls so a clinical artifact can never be committed/pushed, even by an environment-level auto-committer:

- **.gitignore** ignores ALL `*.nest` / `*.sidecar.jsonl` / `**/pairs/` (negating only the three sanctioned public corpora), so it survives a `git add -A --no-verify`.
- **scripts/pre-commit** aborts a forced stage of any non-allow-listed data artifact.
- **doc/phi-safety.md** records the threat model, the three controls, and re-install/verify steps.

Diff: 3 files, +125/-0. No code, no behavior change — infra only, safe to merge first and independently.