### PR TITLE
hardening: audit remediation — hostile-input bounds, model_hash gate, dependency advisories, CI gates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+# dependabot configuration. simple by design: weekly cadence, capped pr count,
+# explicit scope. update when adding new package ecosystems.
+#
+# pip is intentionally absent: pyproject.toml declares only `>=` floors in a
+# PEP 735 dependency group (no pins, no lockfile), so version updates would
+# have nothing to bump. add the ecosystem if pinned requirements or a Python
+# lockfile ever land.
+#
+# docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+
+updates:
+  # rust workspace at the repo root. Cargo.lock is committed, so updates
+  # target the exact resolved versions the CLI binary ships with.
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - rust
+    commit-message:
+      prefix: cargo
+      include: scope
+    groups:
+      patch-and-minor:
+        update-types:
+          - patch
+          - minor
+
+  # github actions workflows (.github/workflows/).
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: actions
+      include: scope
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,14 +59,12 @@ jobs:
       - run: ruff check python tests
 
   audit:
-    name: cargo-audit (advisory)
+    name: cargo-audit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo install cargo-audit --locked
-      # Informational until the pre-existing advisory backlog is triaged: it
-      # surfaces vulnerable deps in the logs without blocking merges. Flip to a
-      # blocking check once the tree is clean.
+      # Blocking: the advisory backlog was cleared with the pyo3 0.29 bump, so
+      # any new advisory against the committed Cargo.lock should fail CI.
       - run: cargo audit
-        continue-on-error: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "bitflags"
@@ -420,9 +420,9 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -528,9 +528,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
  "libc",
  "once_cell",
@@ -542,18 +542,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -561,9 +561,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -573,13 +573,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]

--- a/crates/nest-python/Cargo.toml
+++ b/crates/nest-python/Cargo.toml
@@ -10,10 +10,10 @@ name = "_nest"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.28", features = ["abi3-py312"] }
+pyo3 = { version = "0.29", features = ["abi3-py312"] }
 nest-format = { workspace = true }
 nest-runtime = { workspace = true }
 serde_json = { workspace = true }
 
 [build-dependencies]
-pyo3-build-config = "0.28"
+pyo3-build-config = "0.29"


### PR DESCRIPTION
Follow-up to #59: clears the dependency-advisory backlog and turns on the guardrails that keep it clear. Two commits, rebased onto main after #59's squash-merge.

## 1. Dependency advisories (`deps:`)

| Crate | Bump | Fixes |
|---|---|---|
| pyo3 | 0.28.3 → 0.29.0 | GHSA-36hh-v3qg-5jq4 (high: OOB read in `PyList`/`PyTuple` iterator `nth`/`nth_back`), GHSA-chgr-c6px-7xpp (missing `Sync` bound on `PyCFunction::new_closure`) — closes all 4 open Dependabot alerts |
| anyhow | 1.0.102 → 1.0.103 | RUSTSEC-2026-0190 (unsound `downcast_mut` after `context`) |
| memmap2 | 0.9.10 → 0.9.11 | RUSTSEC-2026-0186 (unchecked pointer offset in `advise_range`/`flush_range`) |

Exposure assessment: none of the vulnerable call patterns exist in this workspace — the only `PyList` iteration is a `next()`-based for-loop (`build_inputs.rs`), `PyCFunction`/`new_closure` is never used, and neither `downcast_mut`-after-`context` nor `advise_range`/`flush_range` appear anywhere. The bumps are hygiene, and they clear the tree so cargo-audit can gate merges. The anyhow/memmap2 advisories came from an OSV batch query over the full lockfile — Dependabot has not alerted on those two yet.

Migration notes: pyo3 0.29 MSRV is 1.83 (project MSRV is 1.85); `abi3-py312` unchanged; zero source changes required.

## 2. CI gate + dependabot (`ci:`)

- `cargo-audit` flips from `continue-on-error` (advisory) to blocking, per the note left in the workflow — the backlog is now clear.
- `.github/dependabot.yml` restored (removed in #51): weekly `cargo` + `github-actions`, patch/minor grouped into single PRs to keep noise low. `pip` intentionally omitted — `pyproject.toml` only declares `>=` floors in a PEP 735 dependency group, so version updates would have nothing to bump.

## Validation

- `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace --locked`: green locally on the rebased branch (includes the #58 NEON f16 probe path on an arm64 host).
- OSV batch query over all 111 lockfile packages after the bumps: **0 vulnerable entries**.
- The pyo3 bump was additionally trial-built and full-suite-tested in a clean worktree before landing.

## Follow-up (needs repo admin)

Enable **Dependabot security updates** in Settings → Advanced Security so future alerts open PRs automatically (the API rejects non-admin accounts).
