### PR TITLE
docs: fix changelog duplicate header, document image pillar in AGENTS.md

### DIFF
--- a/.contracts/.agents/AGENTS.md
+++ b/.contracts/.agents/AGENTS.md
@@ -28,9 +28,13 @@ abi3 targets python 3.12+ (not 3.14). python tests need the built `.so` first:
 python tests/test_e2e.py
 python tests/test_builder.py
 python tests/test_search_text_model_hash.py
+python tests/test_offline_guard.py
+python tests/test_blob_bridge.py
+python tests/test_space_bridge.py
+python tests/test_image_corpus.py
 ```
 
-no pytest. tests are plain scripts with `if __name__ == "__main__"`. `pytest tests/` does not work.
+no pytest. tests are plain scripts with `if __name__ == "__main__"`. `pytest tests/` does not work. `test_image_corpus.py` (37 cases) exercises the forge image-corpus pillar (encode/decode, gop probe, sharding, ordering) and skips cleanly when ffmpeg's av1/avif encoders are unavailable; it does not need the vision model itself. building an actual image corpus (`python/forge/embed_image.py`) needs `open_clip` + torch, not part of the default forge dependency group.
 
 the forge build-side default embedder is now the REAL SEMANTIC one: a vendored model2vec/potion-base-8M static table (`python/forge/embed_potion.py`), offline, no torch, no network. its self-test needs numpy + tokenizers and the vendored table (git-lfs): `python python/forge/test_embed_potion.py` (run with `.venv/bin/python`; install the deps with `uv pip install numpy tokenizers`, declared in `pyproject.toml` under `[dependency-groups] forge`). it proves the semantic jump (car ~ automobile >> car ~ banana), determinism, f32-stability, and that no socket is opened at embed time; `python python/forge/recall_harness.py` shows per-query recall vs the floor. the table (`python/forge/models/potion-base-8M/model.safetensors`, ~30mb) is git-lfs; run `git lfs pull` if it is a pointer. the #04 lexical bag-of-words stays as the stdlib-only zero-dep FLOOR with its own self-test (no `.so`, no deps): `python python/forge/test_embed_default.py`. both self-fingerprint to a `model_hash` recorded in provenance; neither is run by `release_check.sh`.
 
@@ -109,7 +113,7 @@ identify temporary scripts and possible dead-code files in incorrect folders. un
 
 - rust edition 2024, resolver 3, `thiserror` for errors (never panic in library code).
 - `repr(C)` structs for binary layout; all integers LE unsigned.
-- Wip feature study/progress (not final resolutiom) binary format v1 is frozen. v0.2 added encodings 1/2/3 (zstd, float16, int8) and optional sections 0x07 (HNSW) and 0x08 (BM25).
+- Wip feature study/progress (not final resolutiom) binary format v1 is frozen. v0.2 added encodings 1/2/3 (zstd, float16, int8) and optional sections 0x07 (HNSW) and 0x08 (BM25). v0.3 added encoding 7 (int4) and the graph pillar (section 0x0C). since then the media blob pillar (0x14 blob_refs, 0x16 blob_span_overlay) and the multimodal space pillar (0x15 space_table + the 0x20-0x2F embedding band) shipped, all additive and content_hash-excluded; see `doc/arc/arc.yaml`'s `contract` array for the full section-id map.
 - hash format: always `sha256:<64 lowercase hex>`.
 - four hashes: `header_checksum`, per-section `checksum` (physical bytes), `file_hash` (whole file), `content_hash` (decoded canonical sections, stable across encodings).
 - `NestFileBuilder` is a consuming builder (`add_chunk(self) -> Self`). presets via `.text_encoding()` + `.embedding_dtype()`.

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -66,6 +66,8 @@ both were found by controls that should have been run before publishing, and bot
 
 `--all-intra` (`keyint=1`) stays a lever, default off. it follows from the upstream finding that reordering images changes the ratio by only ~6 percent, so the gain is intra-frame: unrelated images give motion estimation nothing to find and the bits it spends searching are wasted. it buys another 5.2x for 0.6 points of `precision@10`, a difference well inside the interval, and every frame becomes a keyframe so random access has nothing to seek back to.
 
+for the codec-vs-codec question, at matched source resolution and measured on the same 200 images: source jpeg 74.70 MB (6.8 bits/pixel, stored near-lossless), a fair jpeg q95 re-encode 31.87 MB, webp q90 19.44 MB, jpeg q85 16.20 MB, av1 crf35 1.94 MB. so av1 is ~16x smaller than a fair jpeg q95 baseline, and roughly 2.3x of the headline 39.5x is the source having been stored wastefully rather than anything the codec did.
+
 ### changed (2026-08-10, supersedes one line of the 2026-08-07 note)
 
 - the gop is no longer a flag the caller must guess. `gop_policy="auto"` is the builder default: an evenly spaced sample (32 frames) is probe-encoded both ways at the target crf and the smaller stream wins, because fase 0 measured that embedding cosine does not separate intra-favouring from inter-favouring corpora, so the policy is a measured encode decision. the probe statistics (n_samples, intra_bytes, inter_bytes, decision) land in the manifest next to the toolchain provenance. `--gop-policy intra|inter` forces a side, and `--all-intra` keeps working as the explicit intra override. the 2026-08-07 note's "lever, default off" described the flag era.
@@ -104,11 +106,6 @@ the claim that survives verification: nest is, to our knowledge and checked agai
 
 - 340 rust tests in the sovereign workspace (`cargo test --release --workspace`; was 288 in v0.3.0), including the blob_refs and space_table roundtrips, their negative fuzz suites, reserved_ids band disjointness, the runtime blob overlay and space isolation cases, and the content_hash-equality assertions that keep citations stable.
 - python: `tests/test_image_corpus.py` at 37 cases (was 15 in v0.3.0), plus `tests/test_blob_bridge.py` (5) and `tests/test_space_bridge.py` (5), all run by `release_check.sh`; the full gate is green on this change.
-
-## [0.3.0] - 2026-06-10
-
-for the codec-vs-codec question, at matched source resolution and measured on the same 200 images: source jpeg 74.70 MB (6.8 bits/pixel, stored near-lossless), a fair jpeg q95 re-encode 31.87 MB, webp q90 19.44 MB, jpeg q85 16.20 MB, av1 crf35 1.94 MB. so av1 is ~16x smaller than a fair jpeg q95 baseline, and roughly 2.3x of the headline 39.5x is the source having been stored wastefully rather than anything the codec did.
-
 
 ## [0.3.0] - 2026-06-10
 


### PR DESCRIPTION
## what

two gaps found while re-checking doc/usage.md, doc/changelog.md, and .contracts/.agents/AGENTS.md after the arc.md consolidation (#73) — the user asked why those three weren't touched; usage.md was already current, these two were not.

- **doc/changelog.md**: a duplicated `## [0.3.0] - 2026-06-10` header had swallowed the closing paragraph of the Unreleased section's 2026-08-07 note (the jpeg/webp/av1 codec-vs-codec comparison), stranding it in its own spurious section right before the real v0.3.0 entry. moved the paragraph back to where it belongs and removed the duplicate header.
- **.contracts/.agents/AGENTS.md**: the authoritative agent operating contract had zero mention of the media blob pillar, the multimodal space pillar, or the forge image-corpus tooling merged in #71/#72. added the three missing test scripts (test_blob_bridge.py, test_space_bridge.py, test_image_corpus.py) plus the previously unlisted test_offline_guard.py to the test list, noted that the image embedder needs open_clip+torch (not in the default forge dependency group), and extended a stale line that still described the format as stopping at v0.2's sections 0x07/0x08.

## gate

markdown-only changes, no rust or python touched. verified the changelog now has exactly one `## [0.3.0]` header and the moved paragraph reads correctly in context.