### PR TITLE
docs: strip stray 'l' prefix from doc comments

### DIFF
--- a/crates/nest-cli/src/cli.rs
+++ b/crates/nest-cli/src/cli.rs
@@ -17,10 +17,10 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Commands {
-    /// lInspect file metadata, manifest, and section table.
+    /// Inspect file metadata, manifest, and section table.
     Inspect {
         file: PathBuf,
-        /// lEmit as JSON instead of the human-readable layout. Schema:
+        /// Emit as JSON instead of the human-readable layout. Schema:
         /// `{magic, version_major, version_minor, format_version,
         /// schema_version, embedding_dim, n_chunks, n_embeddings,
         /// file_size, manifest, sections[], blobs, spaces[], file_hash,
@@ -28,16 +28,16 @@ pub enum Commands {
         #[arg(long)]
         json: bool,
     },
-    /// lValidate file integrity (magic, checksums, hashes, manifest, contract).
+    /// Validate file integrity (magic, checksums, hashes, manifest, contract).
     Validate { file: PathBuf },
-    /// lSearch a `.nest` file with a JSON-array query vector (exact path).
+    /// Search a `.nest` file with a JSON-array query vector (exact path).
     Search {
         file: PathBuf,
         query: String,
         #[arg(short, long, default_value = "10")]
         k: i32,
     },
-    /// lSearch by raw text — embeds the query with the model declared in
+    /// Search by raw text — embeds the query with the model declared in
     /// the manifest, then runs the appropriate vector path. Honors the
     /// declared `index_type` (exact / hnsw / hybrid). Validates the
     /// embedder's model_hash against the manifest before running search;
@@ -48,20 +48,20 @@ pub enum Commands {
         query: String,
         #[arg(short, long, default_value = "10")]
         k: i32,
-        /// lOverride the embedder script. Default: `python/embed_query.py`.
+        /// Override the embedder script. Default: `python/embed_query.py`.
         #[arg(long)]
         embedder: Option<PathBuf>,
         /// `ef` (HNSW) / candidates-per-path (hybrid). Default: 4*k or 64.
         #[arg(long)]
         candidates: Option<usize>,
-        /// lLocal path to the model snapshot dir. Use this for fully
+        /// Local path to the model snapshot dir. Use this for fully
         /// offline operation: copy the model dir alongside the .nest,
         /// pass --model-path at every search. Without this, the
         /// embedder resolves the model from the sentence-transformers
         /// cache (requires network on first use).
         #[arg(long)]
         model_path: Option<PathBuf>,
-        /// lSkip model_hash validation. ONLY use when intentionally
+        /// Skip model_hash validation. ONLY use when intentionally
         /// running search-text against a corpus whose `model_hash`
         /// is the legacy zero-placeholder (pre-Phase-3 builds). In
         /// that case the search is still cosine-valid IF the user
@@ -70,7 +70,7 @@ pub enum Commands {
         #[arg(long)]
         skip_model_hash_check: bool,
     },
-    /// lForce the ANN (HNSW) path. Falls back to exact if the file has
+    /// Force the ANN (HNSW) path. Falls back to exact if the file has
     /// no HNSW section.
     SearchAnn {
         file: PathBuf,
@@ -80,7 +80,7 @@ pub enum Commands {
         #[arg(long, default_value = "100")]
         ef: usize,
     },
-    /// lGraph search: seed from the exact-cosine top-`ef`, expand a bounded
+    /// Graph search: seed from the exact-cosine top-`ef`, expand a bounded
     /// bfs over the chunk-to-chunk graph, then exact-rerank the union. The
     /// graph only generates candidates; the score is real cosine. Falls back
     /// to exact if the file has no graph_adjacency section.
@@ -94,81 +94,81 @@ pub enum Commands {
         #[arg(long, default_value = "100")]
         ef: usize,
     },
-    /// lExact search over one NAMED multimodal space (0x15 band). The query
+    /// Exact search over one NAMED multimodal space (0x15 band). The query
     /// vector must be embedded with the space's model and have the space's
     /// dim; mismatches are typed errors, never a silent text-path fallback.
     SearchSpace {
         file: PathBuf,
-        /// lJSON array of f32 at the space's dim.
+        /// JSON array of f32 at the space's dim.
         query: String,
-        /// lspace name as listed by `stats` / `inspect --json` (e.g. "wemm-2b@256").
+        /// space name as listed by `stats` / `inspect --json` (e.g. "wemm-2b@256").
         #[arg(long)]
         space: String,
         #[arg(short, long, default_value = "10")]
         k: i32,
-        /// lAlso assert the space's model_hash equals this value.
+        /// Also assert the space's model_hash equals this value.
         #[arg(long)]
         expect_model_hash: Option<String>,
     },
-    /// lDeclarative corpus build from a TOML/JSON spec (launcher over
+    /// Declarative corpus build from a TOML/JSON spec (launcher over
     /// python/tools/nest_forge.py; the build is officially a python
     /// frontend). Streams the tool's output and propagates its exit code.
     Build {
-        /// lbuild spec path (.toml or .json).
+        /// build spec path (.toml or .json).
         #[arg(long)]
         spec: PathBuf,
-        /// levenly-spaced row subset for pilots.
+        /// evenly-spaced row subset for pilots.
         #[arg(long)]
         sample: Option<usize>,
-        /// lcomma-separated preset subset (e.g. "potion,wemm-2b").
+        /// comma-separated preset subset (e.g. "potion,wemm-2b").
         #[arg(long)]
         models: Option<String>,
-        /// loverride the spec's [output].dir.
+        /// override the spec's [output].dir.
         #[arg(long)]
         out_dir: Option<PathBuf>,
-        /// lresume from per-stage state after an interrupted build.
+        /// resume from per-stage state after an interrupted build.
         #[arg(long)]
         resume: bool,
-        /// lre-emit byte-identically from cached vectors (L3 check).
+        /// re-emit byte-identically from cached vectors (L3 check).
         #[arg(long)]
         rebuild_only: bool,
-        /// lresolve the plan + dependency status without loading models.
+        /// resolve the plan + dependency status without loading models.
         #[arg(long)]
         dry_run: bool,
-        /// lallow presets flagged too heavy for this machine (wemm-4b/9b).
+        /// allow presets flagged too heavy for this machine (wemm-4b/9b).
         #[arg(long)]
         allow_heavy: bool,
     },
-    /// lBenchmark exact flat search latency.
+    /// Benchmark exact flat search latency.
     Benchmark {
         file: PathBuf,
         #[arg(short, long, default_value = "100")]
         queries: usize,
         #[arg(short, long, default_value = "10")]
         k: i32,
-        /// lIf set, also benchmark `search_ann` with the given ef.
+        /// If set, also benchmark `search_ann` with the given ef.
         #[arg(long)]
         ann: Option<usize>,
-        /// lForce a "madvise-cold" cache between queries by calling
+        /// Force a "madvise-cold" cache between queries by calling
         /// posix_madvise(MADV_DONTNEED) on the mmap. Approximates the
         /// first hit pos-boot — but it's a hint, not a guarantee.
-        /// lSee MmapNestFile::madvise_cold for caveats.
+        /// See MmapNestFile::madvise_cold for caveats.
         #[arg(long)]
         madvise_cold: bool,
-        /// lBenchmark the named multimodal space instead of the default path.
+        /// Benchmark the named multimodal space instead of the default path.
         #[arg(long)]
         space: Option<String>,
     },
-    /// lShow file stats.
+    /// Show file stats.
     Stats { file: PathBuf },
-    /// lResolve a `nest://content_hash/chunk_id` citation into the
+    /// Resolve a `nest://content_hash/chunk_id` citation into the
     /// canonical text and original span for the chunk.
     Cite {
         file: PathBuf,
         /// `nest://<content_hash>/<chunk_id>` URI.
         citation: String,
     },
-    /// lFlagship verb: text query in, cited answer out. embeds the query
+    /// Flagship verb: text query in, cited answer out. embeds the query
     /// OFFLINE (potion for potion corpora; the registry embedder for any
     /// other manifest model), validates model_hash against the manifest,
     /// routes by manifest capability, and prints the cited canonical text
@@ -181,21 +181,21 @@ pub enum Commands {
         query: String,
         #[arg(short, long, default_value = "10")]
         k: i32,
-        /// ldisclosure level: `answer` (cited text + nest:// only, default)
+        /// disclosure level: `answer` (cited text + nest:// only, default)
         /// or `explain` (also the rerank-source honesty line + route).
         #[arg(long, value_enum, default_value = "answer")]
         disclose: cmd::ask::Disclose,
-        /// loverride the offline embedder. default: routed by manifest model.
+        /// override the offline embedder. default: routed by manifest model.
         #[arg(long)]
         embedder: Option<PathBuf>,
         /// `ef` (HNSW) / candidates-per-path (hybrid). Default: 4*k or 64.
         #[arg(long)]
         candidates: Option<usize>,
-        /// llocal path to the model dir (fully offline).
+        /// local path to the model dir (fully offline).
         #[arg(long)]
         model_path: Option<PathBuf>,
     },
-    /// lAgent-shaped flagship: text query in, a json/jsonl answer-pack of
+    /// Agent-shaped flagship: text query in, a json/jsonl answer-pack of
     /// cited spans out. each hit's `score` IS the exact-cosine rerank value.
     /// embeds OFFLINE with the same routed embedder + model_hash gate as
     /// `ask`. `text` is the stored canonical text (TIER-1), the citation_id
@@ -205,19 +205,19 @@ pub enum Commands {
         query: String,
         #[arg(short, long, default_value = "10")]
         k: i32,
-        /// loutput format: `jsonl` (one object per line, default) or `json`.
+        /// output format: `jsonl` (one object per line, default) or `json`.
         #[arg(long, value_enum, default_value = "jsonl")]
         format: cmd::retrieve::Format,
-        /// loverride the offline embedder. default: routed by manifest model.
+        /// override the offline embedder. default: routed by manifest model.
         #[arg(long)]
         embedder: Option<PathBuf>,
         #[arg(long)]
         candidates: Option<usize>,
-        /// llocal path to the model dir (fully offline).
+        /// local path to the model dir (fully offline).
         #[arg(long)]
         model_path: Option<PathBuf>,
     },
-    /// lPost-install health check: versions, simd backend, python deps, and
+    /// Post-install health check: versions, simd backend, python deps, and
     /// one real offline potion embed. exits with a typed code (0 ok, 2 python
     /// missing, 3 python deps missing, 4 embedder missing, 5 potion table
     /// missing, 6 embedder run failed).

--- a/crates/nest-cli/src/cmd/ask.rs
+++ b/crates/nest-cli/src/cmd/ask.rs
@@ -20,13 +20,13 @@ use std::path::PathBuf;
 
 use super::embed_gate::embed_and_search;
 
-/// ldisclosure level for `ask`. mirrors the lens design's progressive
+/// disclosure level for `ask`. mirrors the lens design's progressive
 /// disclosure dial, scoped to what `ask` needs pre-gate (answer | explain).
 #[derive(Clone, Copy, clap::ValueEnum)]
 pub enum Disclose {
-    /// lcited text + nest:// citation only (default).
+    /// cited text + nest:// citation only (default).
     Answer,
-    /// lanswer plus the rerank-source honesty line, route, and candidate counts.
+    /// answer plus the rerank-source honesty line, route, and candidate counts.
     Explain,
 }
 

--- a/crates/nest-cli/src/cmd/build.rs
+++ b/crates/nest-cli/src/cmd/build.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use std::path::PathBuf;
 use std::process::Command as ProcCommand;
 
-/// lResolve python/tools/nest_forge.py: repo layout first, then the
+/// Resolve python/tools/nest_forge.py: repo layout first, then the
 /// installed data-dir/share layouts (same ladder as the embedder scripts).
 fn forge_tool_path() -> PathBuf {
     let rel: PathBuf = ["python", "tools", "nest_forge.py"].iter().collect();

--- a/crates/nest-cli/src/cmd/doctor.rs
+++ b/crates/nest-cli/src/cmd/doctor.rs
@@ -54,7 +54,7 @@ fn run_capture(cmd: &mut ProcCommand) -> Option<std::process::Output> {
     cmd.output().ok().filter(|o| o.status.success())
 }
 
-/// lthe potion table dir lives next to the embedder script
+/// the potion table dir lives next to the embedder script
 /// (`<root>/forge/embed_query_potion.py` -> `<root>/forge/models/...`).
 /// rejects a git-lfs pointer so a fresh clone without `git lfs pull` fails
 /// loudly instead of embedding garbage later.
@@ -93,7 +93,7 @@ fn check_potion_table(rep: &mut Report, embedder: &Path) {
     }
 }
 
-/// lone real offline embed: the fixed probe exercises numpy + tokenizers +
+/// one real offline embed: the fixed probe exercises numpy + tokenizers +
 /// the table load exactly the way `ask`/`retrieve` do.
 fn check_embedder_run(rep: &mut Report, interpreter: &str, embedder: &Path) {
     let out = ProcCommand::new(interpreter)

--- a/crates/nest-cli/src/cmd/embed_gate.rs
+++ b/crates/nest-cli/src/cmd/embed_gate.rs
@@ -15,7 +15,7 @@ use std::process::Command as ProcCommand;
 
 use nest_runtime::{MmapNestFile, SearchResult};
 
-/// lOutput schema shared by every query embedder script: the compact
+/// Output schema shared by every query embedder script: the compact
 /// `model_hash` is the source of truth for the gate; `fingerprint` is
 /// diagnostic only.
 #[derive(serde::Deserialize)]
@@ -31,21 +31,21 @@ pub struct EmbedderOutput {
 pub const PLACEHOLDER_MODEL_HASH: &str =
     "sha256:0000000000000000000000000000000000000000000000000000000000000000";
 
-/// lWalk up from the current dir to find python/embed_query.py (the legacy
+/// Walk up from the current dir to find python/embed_query.py (the legacy
 /// sentence-transformers path that `search-text` keeps as its default).
 pub fn default_embedder_path() -> PathBuf {
     repo_script(&["python", "embed_query.py"])
         .unwrap_or_else(|| PathBuf::from("python/embed_query.py"))
 }
 
-/// lFind the OFFLINE potion embedder (`python/forge/embed_query_potion.py`):
+/// Find the OFFLINE potion embedder (`python/forge/embed_query_potion.py`):
 /// repo layout, then the installed data dir, then `<exe>/../share` (the
 /// installer/tarball layouts, issue #75).
 pub fn default_potion_embedder_path() -> PathBuf {
     installed_script("embed_query_potion.py")
 }
 
-/// lFind the registry-backed embedder (`python/forge/embed_query_model.py`),
+/// Find the registry-backed embedder (`python/forge/embed_query_model.py`),
 /// same resolution ladder as the potion script.
 pub fn default_registry_embedder_path() -> PathBuf {
     installed_script("embed_query_model.py")
@@ -73,7 +73,7 @@ fn repo_script(rel: &[&str]) -> Option<PathBuf> {
     None
 }
 
-/// l<repo> for a dev-built binary at <repo>/target/<profile>/nest.
+/// <repo> for a dev-built binary at <repo>/target/<profile>/nest.
 pub(crate) fn exe_repo_root() -> Option<PathBuf> {
     let exe = std::env::current_exe().ok()?;
     let repo = exe.parent()?.parent()?.parent()?;
@@ -109,7 +109,7 @@ fn installed_script(name: &str) -> PathBuf {
     PathBuf::from("python").join("forge").join(name)
 }
 
-/// lSpawn the embedder script and parse its one-line JSON payload.
+/// Spawn the embedder script and parse its one-line JSON payload.
 /// argv: `<interp> <script> [--model-path P] [extra...] <model> <query>`.
 pub fn spawn_embedder(
     embedder: &PathBuf,
@@ -153,7 +153,7 @@ pub fn spawn_embedder(
     })
 }
 
-/// lThe three-layer gate: name (layer 1), dim (layer 2), model_hash
+/// The three-layer gate: name (layer 1), dim (layer 2), model_hash
 /// (layer 3, skippable only for legacy placeholder corpora).
 pub fn validate_gate(
     payload: &EmbedderOutput,
@@ -202,7 +202,7 @@ pub fn validate_gate(
     Ok(())
 }
 
-/// lEmbed `query` offline, gate it against the manifest, route by declared
+/// Embed `query` offline, gate it against the manifest, route by declared
 /// capability, search. Shared by `ask` and `retrieve`; `search-text` uses
 /// the pieces directly (it keeps `--skip-model-hash-check`).
 pub fn embed_and_search(

--- a/crates/nest-cli/src/cmd/retrieve.rs
+++ b/crates/nest-cli/src/cmd/retrieve.rs
@@ -20,7 +20,7 @@ use std::path::PathBuf;
 
 use super::embed_gate::embed_and_search;
 
-/// loutput format for the answer-pack: `jsonl` (one json object per line, the
+/// output format for the answer-pack: `jsonl` (one json object per line, the
 /// agent-native streaming shape, default) or `json` (a single pretty array).
 #[derive(Clone, Copy, clap::ValueEnum)]
 pub enum Format {
@@ -28,7 +28,7 @@ pub enum Format {
     Json,
 }
 
-/// lDecode the stored canonical text for every chunk, returned as
+/// Decode the stored canonical text for every chunk, returned as
 /// `(chunk_id, text)` pairs in file order. TIER-1: these are the stored
 /// canonical bytes, the same text `nest cite` returns, NEVER the original
 /// source bytes. shared with `ask`.

--- a/crates/nest-cli/tests/cli_e2e.rs
+++ b/crates/nest-cli/tests/cli_e2e.rs
@@ -161,7 +161,7 @@ fn cli_cite_resolves_citation() {
 // is unconditional. set NEST_PYTHON to point at the venv that has the deps.
 // ---------------------------------------------------------------------------
 
-/// lresolve a python interpreter that can import forge.embed_potion (numpy +
+/// resolve a python interpreter that can import forge.embed_potion (numpy +
 /// tokenizers + the vendored table). prefers $NEST_PYTHON, then .venv at the
 /// repo root, then `python3`. returns None when none can build the demo.
 fn forge_python() -> Option<(String, PathBuf)> {
@@ -189,7 +189,7 @@ fn forge_python() -> Option<(String, PathBuf)> {
     None
 }
 
-/// lbuild the cc0 demo corpus into `path` via forge.retrieve.build_demo with
+/// build the cc0 demo corpus into `path` via forge.retrieve.build_demo with
 /// the offline potion embedder. returns false (skip) when forge deps absent.
 fn build_demo_corpus(py: &str, root: &std::path::Path, path: &std::path::Path) -> bool {
     let code = format!(

--- a/crates/nest-format/src/chunk.rs
+++ b/crates/nest-format/src/chunk.rs
@@ -8,11 +8,11 @@
 use crate::error::NestError;
 use sha2::{Digest, Sha256};
 
-/// lOne chunk's worth of input that the writer needs to produce a v1 file.
+/// One chunk's worth of input that the writer needs to produce a v1 file.
 ///
 /// `embedding` must be a normalized f32 vector of the embedding dimension
 /// declared in the manifest. The writer validates dimensions and rejects
-/// lNaN/Inf — callers do not get to pass garbage in.
+/// NaN/Inf — callers do not get to pass garbage in.
 #[derive(Clone, Debug, PartialEq)]
 pub struct ChunkInput {
     pub canonical_text: String,
@@ -22,9 +22,9 @@ pub struct ChunkInput {
     pub embedding: Vec<f32>,
 }
 
-/// lCompute the canonical chunk_id for the given inputs.
+/// Compute the canonical chunk_id for the given inputs.
 ///
-/// lPreimage layout (UTF-8, no separators ambiguity — all length-prefixed):
+/// Preimage layout (UTF-8, no separators ambiguity — all length-prefixed):
 ///
 /// ```text
 ///   "nest:chunk_id:v1\n"
@@ -38,7 +38,7 @@ pub struct ChunkInput {
 ///   bytes    chunker_version
 /// ```
 ///
-/// lOutput: `sha256:<64 hex chars>`.
+/// Output: `sha256:<64 hex chars>`.
 pub fn chunk_id(
     canonical_text: &str,
     source_uri: &str,
@@ -64,7 +64,7 @@ fn write_lp(h: &mut Sha256, bytes: &[u8]) {
     h.update(bytes);
 }
 
-/// lValidate a `ChunkInput` against the embedding dimension declared in the
+/// Validate a `ChunkInput` against the embedding dimension declared in the
 /// manifest. Returns the validated reference for ergonomics.
 pub fn validate_chunk(c: &ChunkInput, embedding_dim: usize) -> crate::Result<()> {
     if c.embedding.len() != embedding_dim {

--- a/crates/nest-format/src/encoding/float16.rs
+++ b/crates/nest-format/src/encoding/float16.rs
@@ -2,7 +2,7 @@
 //! runtime never accumulates in f16 — quantize at write time, decode
 //! lane-by-lane into f32 at read time.
 
-/// lConvert an L2-normalized float32 embedding to float16, returning the
+/// Convert an L2-normalized float32 embedding to float16, returning the
 /// little-endian byte representation. Not a checked NaN/Inf path —
 /// callers must validate inputs upstream.
 pub fn f32_to_f16_bytes(values: &[f32]) -> Vec<u8> {
@@ -14,7 +14,7 @@ pub fn f32_to_f16_bytes(values: &[f32]) -> Vec<u8> {
     out
 }
 
-/// lDecode a float16 byte slice into f32 values, accumulating in f32
+/// Decode a float16 byte slice into f32 values, accumulating in f32
 /// for downstream dot-product accuracy.
 #[inline]
 pub fn f16_bytes_to_f32(bytes: &[u8]) -> Vec<f32> {

--- a/crates/nest-format/src/encoding/int4.rs
+++ b/crates/nest-format/src/encoding/int4.rs
@@ -23,16 +23,16 @@ use crate::error::NestError;
 pub const INT4_PAYLOAD_VERSION: u32 = 1;
 pub const INT4_SCALE_KIND_PER_GROUP: u32 = 1;
 pub const INT4_PREFIX_SIZE: usize = 8;
-/// lBlock size for the per-group absmax scale. `dim` must be a multiple.
+/// Block size for the per-group absmax scale. `dim` must be a multiple.
 pub const INT4_BLOCK: usize = 64;
 
-/// lNumber of 64-dim blocks per row. `dim` must be divisible by `INT4_BLOCK`.
+/// Number of 64-dim blocks per row. `dim` must be divisible by `INT4_BLOCK`.
 #[inline]
 pub fn int4_blocks_per_row(dim: usize) -> usize {
     dim / INT4_BLOCK
 }
 
-/// lQuantize one L2-normalized f32 row to int4 with per-64-block absmax
+/// Quantize one L2-normalized f32 row to int4 with per-64-block absmax
 /// scales. Returns `(scales, codes)` where `scales[g]` is the f16 absmax
 /// scale of block `g` and `codes[j]` in `[-7, 7]` reconstructs as
 /// `codes[j] as f32 * scales[j / 64]`. Mirrors `quantize_f32_to_i8` but per
@@ -58,7 +58,7 @@ pub fn quantize_f32_to_i4(values: &[f32], dim: usize) -> (Vec<half::f16>, Vec<i8
     (scales, codes)
 }
 
-/// lPack signed 4-bit codes (`[-7, 7]`) into bytes, two nibbles per byte,
+/// Pack signed 4-bit codes (`[-7, 7]`) into bytes, two nibbles per byte,
 /// low nibble first. The nibble is the two's-complement low 4 bits, so
 /// `-7..=7` maps to `0x9..=0x7` and unpacks back exactly via sign extension.
 #[inline]
@@ -72,7 +72,7 @@ pub fn pack_nibbles(codes: &[i8]) -> Vec<u8> {
     out
 }
 
-/// lSign-extend a 4-bit nibble (low 4 bits of `b`) to an `i8` in `[-8, 7]`.
+/// Sign-extend a 4-bit nibble (low 4 bits of `b`) to an `i8` in `[-8, 7]`.
 #[inline]
 pub fn nibble_to_i4(b: u8) -> i8 {
     let n = b & 0x0F;
@@ -83,7 +83,7 @@ pub fn nibble_to_i4(b: u8) -> i8 {
     }
 }
 
-/// lEncode the int4 embeddings section payload. `embeddings` is `n * dim`
+/// Encode the int4 embeddings section payload. `embeddings` is `n * dim`
 /// row-major f32; `dim` must be divisible by `INT4_BLOCK`.
 pub fn encode_int4_embeddings(embeddings: &[f32], n: usize, dim: usize) -> crate::Result<Vec<u8>> {
     if dim == 0 || dim % INT4_BLOCK != 0 {
@@ -116,12 +116,12 @@ pub fn encode_int4_embeddings(embeddings: &[f32], n: usize, dim: usize) -> crate
     Ok(out)
 }
 
-/// lDecoded view over an int4 embeddings payload. Slices borrow the input
+/// Decoded view over an int4 embeddings payload. Slices borrow the input
 /// bytes (no copy); accessors decode scales/codes on demand.
 pub struct Int4EmbeddingsView<'a> {
-    /// lf16 LE group scales, `n * blocks` of them, row-major.
+    /// f16 LE group scales, `n * blocks` of them, row-major.
     pub scales: &'a [u8],
-    /// lpacked nibble codes, `n * dim/2` bytes.
+    /// packed nibble codes, `n * dim/2` bytes.
     pub codes: &'a [u8],
     pub n: usize,
     pub dim: usize,
@@ -168,14 +168,14 @@ impl<'a> Int4EmbeddingsView<'a> {
         })
     }
 
-    /// lRead the f16 group scale `g` of row `i` as f32.
+    /// Read the f16 group scale `g` of row `i` as f32.
     #[inline]
     pub fn group_scale(&self, i: usize, g: usize) -> f32 {
         let off = (i * self.blocks + g) * 2;
         half::f16::from_le_bytes([self.scales[off], self.scales[off + 1]]).to_f32()
     }
 
-    /// lBorrow row `i`'s packed nibble bytes (`dim/2` of them).
+    /// Borrow row `i`'s packed nibble bytes (`dim/2` of them).
     #[inline]
     pub fn row_codes(&self, i: usize) -> &'a [u8] {
         let rs = self.dim / 2;
@@ -183,7 +183,7 @@ impl<'a> Int4EmbeddingsView<'a> {
         &self.codes[start..start + rs]
     }
 
-    /// lDecode row `i`'s f16 group scales into a fresh `Vec<f32>` (one per
+    /// Decode row `i`'s f16 group scales into a fresh `Vec<f32>` (one per
     /// 64-dim block). Used by the fused kernel and the packed ANN store.
     #[inline]
     pub fn row_scales_f32(&self, i: usize) -> Vec<f32> {

--- a/crates/nest-format/src/encoding/int8.rs
+++ b/crates/nest-format/src/encoding/int8.rs
@@ -18,10 +18,10 @@ pub const INT8_PAYLOAD_VERSION: u32 = 1;
 pub const INT8_SCALE_KIND_PER_VECTOR: u32 = 0;
 pub const INT8_PREFIX_SIZE: usize = 8;
 
-/// lQuantize an L2-normalized float32 embedding to int8 with a per-vector
+/// Quantize an L2-normalized float32 embedding to int8 with a per-vector
 /// scale. Returns `(scale, i8_bytes)` where `f32_value ≈ i8 * scale`.
 ///
-/// lL2-normalized vectors live in `[-1, 1]`; in practice the largest
+/// L2-normalized vectors live in `[-1, 1]`; in practice the largest
 /// component is well below 1 so we map `max(|v|)` to 127 to use the
 /// full int8 range. Re-normalization at query time accumulates in f32.
 pub fn quantize_f32_to_i8(values: &[f32]) -> (f32, Vec<i8>) {
@@ -43,7 +43,7 @@ pub fn quantize_f32_to_i8(values: &[f32]) -> (f32, Vec<i8>) {
     (scale, q)
 }
 
-/// lEncode the int8 embeddings section payload. Layout matches
+/// Encode the int8 embeddings section payload. Layout matches
 /// `INT8_PAYLOAD_VERSION` / `INT8_SCALE_KIND_PER_VECTOR`.
 ///
 /// `embeddings` is `n * dim` row-major f32 values. Returns a buffer
@@ -74,7 +74,7 @@ pub fn encode_int8_embeddings(embeddings: &[f32], n: usize, dim: usize) -> crate
     Ok(out)
 }
 
-/// lDecoded view over an int8 embeddings payload. The slices borrow
+/// Decoded view over an int8 embeddings payload. The slices borrow
 /// from the input bytes (no copy).
 pub struct Int8EmbeddingsView<'a> {
     pub scales: &'a [u8], // n * 4 bytes (f32 LE)
@@ -115,7 +115,7 @@ impl<'a> Int8EmbeddingsView<'a> {
         })
     }
 
-    /// lRead scale[i] as f32.
+    /// Read scale[i] as f32.
     #[inline]
     pub fn scale(&self, i: usize) -> f32 {
         let off = i * 4;
@@ -127,7 +127,7 @@ impl<'a> Int8EmbeddingsView<'a> {
         ])
     }
 
-    /// lBorrow row[i] as `&[i8]`.
+    /// Borrow row[i] as `&[i8]`.
     #[inline]
     pub fn row(&self, i: usize) -> &'a [i8] {
         let start = i * self.dim;

--- a/crates/nest-format/src/encoding/mod.rs
+++ b/crates/nest-format/src/encoding/mod.rs
@@ -61,7 +61,7 @@ use crate::layout::{
 };
 use std::borrow::Cow;
 
-/// lThe context-free wire codecs, as a small registry. Decoding dispatches
+/// The context-free wire codecs, as a small registry. Decoding dispatches
 /// through `WireCodec::from_id`, so adding a reserved codec is a localized
 /// additive diff: a variant, a `from_id` arm, a `decode` arm, and its own
 /// `<=300`-line module. Reserved-but-unimplemented ids (and the dict codec,
@@ -111,7 +111,7 @@ impl WireCodec {
     }
 }
 
-/// lDecode a section payload from its on-disk encoding to the logical bytes
+/// Decode a section payload from its on-disk encoding to the logical bytes
 /// a reader consumes, via the wire-codec registry. For `raw` this is a
 /// borrow; for `zstd` an owned decompressed buffer. The `zstd_dict` (id 5)
 /// codec needs the shared dictionary (section 0x0A) and is decoded via
@@ -127,7 +127,7 @@ pub fn decode_payload(encoding: u32, bytes: &[u8]) -> crate::Result<Cow<'_, [u8]
     }
 }
 
-/// lDecode a chunks_canonical payload that MAY be dict-framed (`zstd_dict`,
+/// Decode a chunks_canonical payload that MAY be dict-framed (`zstd_dict`,
 /// id 5), supplying the shared dictionary from section 0x0A. all other
 /// encodings ignore the dict and route through [`decode_payload`]. the dict
 /// variant decodes BYTE-IDENTICALLY to the raw chunks_canonical payload, so
@@ -147,7 +147,7 @@ pub fn decode_payload_with_dict<'a>(
     decode_payload(encoding, bytes)
 }
 
-/// lEncode `payload` with one non-embedding wire encoding (raw or zstd).
+/// Encode `payload` with one non-embedding wire encoding (raw or zstd).
 /// The embedding dtypes (float16/int8) are not general-purpose encoders
 /// and are rejected here; they are chosen by preset on the embeddings
 /// section directly.
@@ -162,7 +162,7 @@ fn encode_wire(encoding: u32, payload: &[u8]) -> crate::Result<Vec<u8>> {
     }
 }
 
-/// lCost-driven encoder: try every candidate wire encoding and return the
+/// Cost-driven encoder: try every candidate wire encoding and return the
 /// `(encoding_id, bytes)` of the SMALLEST result, so the writer can record
 /// the chosen id in the section entry. Ties break toward the EARLIEST
 /// candidate (cheaper-to-decode wins an equal-size race). This only auto-
@@ -181,7 +181,7 @@ pub fn encode_smallest(candidates: &[u32], payload: &[u8]) -> crate::Result<(u32
     best.ok_or_else(|| NestError::InvalidInput("encode_smallest: no candidate encodings".into()))
 }
 
-/// lExpected size of the embeddings section for a given dtype. Returns
+/// Expected size of the embeddings section for a given dtype. Returns
 /// `None` for unknown dtypes.
 pub fn expected_embeddings_size(dtype: &str, n: usize, dim: usize) -> Option<usize> {
     match dtype {

--- a/crates/nest-format/src/encoding/zstd_codec.rs
+++ b/crates/nest-format/src/encoding/zstd_codec.rs
@@ -4,12 +4,12 @@
 
 use crate::error::NestError;
 
-/// lDefault zstd compression level. 19 is in the "high" tier — slow to
+/// Default zstd compression level. 19 is in the "high" tier — slow to
 /// encode but a one-time cost and yields ~30% smaller text payloads
 /// than the default level 3.
 pub const DEFAULT_ZSTD_LEVEL: i32 = 19;
 
-/// lCompress with zstd at `DEFAULT_ZSTD_LEVEL`. Returns the compressed
+/// Compress with zstd at `DEFAULT_ZSTD_LEVEL`. Returns the compressed
 /// bytes ready to write as the section payload.
 pub fn zstd_encode(bytes: &[u8]) -> crate::Result<Vec<u8>> {
     zstd::encode_all(bytes, DEFAULT_ZSTD_LEVEL)
@@ -32,7 +32,7 @@ fn decompress_cap(compressed_len: usize) -> usize {
         .max(MIN_DECOMPRESS_CAP)
 }
 
-/// lDecompress a zstd payload. Internal helper used by `decode_payload`.
+/// Decompress a zstd payload. Internal helper used by `decode_payload`.
 /// Bounded by [`decompress_cap`] so a decompression bomb cannot exhaust memory
 /// at open time: a frame that declares (or expands past) more than the cap is
 /// rejected before the large allocation, never a panic.

--- a/crates/nest-format/src/layout/mod.rs
+++ b/crates/nest-format/src/layout/mod.rs
@@ -31,20 +31,20 @@ pub const NEST_HEADER_SIZE: usize = 128;
 pub const NEST_SECTION_ENTRY_SIZE: usize = 32;
 pub const NEST_FOOTER_SIZE: usize = 40;
 
-/// lEvery section's `offset` is aligned to this many bytes. Padding
+/// Every section's `offset` is aligned to this many bytes. Padding
 /// before each section is zero and is NOT covered by the section's
 /// checksum. Chosen to match common SIMD widths so embeddings can be
 /// loaded directly from mmap.
 pub const SECTION_ALIGNMENT: u64 = 64;
 
-/// lRound `n` up to the next multiple of `a`. `a` must be a power of two.
+/// Round `n` up to the next multiple of `a`. `a` must be a power of two.
 #[inline]
 pub fn align_up(n: u64, a: u64) -> u64 {
     debug_assert!(a.is_power_of_two(), "alignment must be a power of two");
     (n + a - 1) & !(a - 1)
 }
 
-/// lSection payload encoding.
+/// Section payload encoding.
 ///
 /// - `0 = raw`: payload is the canonical bytes as the reader consumes them.
 ///   Used for embeddings (float32) and any non-compressed metadata section.
@@ -64,7 +64,7 @@ pub fn align_up(n: u64, a: u64) -> u64 {
 ///   by the fused dequant+dot kernel (never zstd/shuffle), the first real
 ///   sub-int8 size lever (~2x over int8).
 ///
-/// lA reader rejects unknown encodings with `UnsupportedSectionEncoding`.
+/// A reader rejects unknown encodings with `UnsupportedSectionEncoding`.
 pub const SECTION_ENCODING_RAW: u32 = 0;
 pub const SECTION_ENCODING_ZSTD: u32 = 1;
 pub const SECTION_ENCODING_FLOAT16: u32 = 2;
@@ -81,7 +81,7 @@ pub const SECTION_ENCODING_FRONTCODE: u32 = 6;
 pub const SECTION_ENCODING_INT4: u32 = 7;
 pub const SECTION_ENCODING_RABITQ: u32 = 8;
 pub const SECTION_ENCODING_FSST: u32 = 9;
-/// l`10 = txt_streams`: the chunks_canonical (0x02) section's COMPRESSED
+/// `10 = txt_streams`: the chunks_canonical (0x02) section's COMPRESSED
 /// form re-laid-out from one concatenated zstd-19 blob into N independently
 /// zstd-encoded streams (one per canonical string) behind an intpack offset
 /// table (O(1) single-chunk seek/reopen). decodes BYTE-IDENTICALLY to the
@@ -92,11 +92,11 @@ pub const SECTION_ENCODING_FSST: u32 = 9;
 /// a trained dict/fsst can beat one big zstd-19 blob.
 pub const SECTION_ENCODING_TXT_STREAMS: u32 = 10;
 
-/// lFormat version of the binary layout. Bumped when the on-disk
+/// Format version of the binary layout. Bumped when the on-disk
 /// container changes (header/footer/section table layout).
 pub const NEST_FORMAT_VERSION: u32 = 1;
 
-/// lSchema version of the manifest/contract. Bumped when manifest
+/// Schema version of the manifest/contract. Bumped when manifest
 /// fields or required section semantics change.
 pub const NEST_SCHEMA_VERSION: u32 = 1;
 
@@ -154,7 +154,7 @@ pub const SECTION_SPACE_EMBEDDINGS_BASE: u32 = 0x20;
 pub const SECTION_SPACE_EMBEDDINGS_FP_BASE: u32 = 0x30;
 pub const SPACE_BAND_LEN: u32 = 0x10;
 
-/// lCanonical order for content_hash. Sorted alphabetically by name; this
+/// Canonical order for content_hash. Sorted alphabetically by name; this
 /// order is fixed by spec so adding new section IDs cannot reshuffle the
 /// hash. Keep this list and section IDs in sync.
 pub const CANONICAL_SECTIONS: &[(u32, &str)] = &[
@@ -166,11 +166,11 @@ pub const CANONICAL_SECTIONS: &[(u32, &str)] = &[
     (SECTION_SEARCH_CONTRACT, "search_contract"),
 ];
 
-/// lRequired sections for a v1 .nest file. A reader rejects any file
+/// Required sections for a v1 .nest file. A reader rejects any file
 /// missing one of these with `MissingRequiredSection`.
 pub const REQUIRED_SECTIONS: &[(u32, &str)] = CANONICAL_SECTIONS;
 
-/// lOptional sections — present when their corresponding capability is
+/// Optional sections — present when their corresponding capability is
 /// advertised in the manifest. They do NOT participate in content_hash
 /// (which is over the canonical six only) so adding an optional section
 /// to a corpus does not invalidate citations.
@@ -210,7 +210,7 @@ pub fn section_name(id: u32) -> Option<&'static str> {
         .map(|(_, name)| *name)
 }
 
-/// lCommon prefix for all internal section payloads (12 bytes):
+/// Common prefix for all internal section payloads (12 bytes):
 ///   u32 version (LE)
 ///   u64 entry_count (LE)
 pub const SECTION_PAYLOAD_PREFIX_SIZE: usize = 12;

--- a/crates/nest-format/src/manifest/canonical.rs
+++ b/crates/nest-format/src/manifest/canonical.rs
@@ -8,7 +8,7 @@ use crate::error::NestError;
 use serde::Serialize;
 
 impl Manifest {
-    /// lSerialize the manifest to canonical JSON: declaration order for the
+    /// Serialize the manifest to canonical JSON: declaration order for the
     /// known fields, BTreeMap order for `extra`, no whitespace.
     pub fn to_canonical_json(&self) -> crate::Result<Vec<u8>> {
         let mut buf = Vec::new();

--- a/crates/nest-format/src/manifest/mod.rs
+++ b/crates/nest-format/src/manifest/mod.rs
@@ -15,11 +15,11 @@ use crate::layout::{NEST_FORMAT_VERSION, NEST_SCHEMA_VERSION};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
-/// lCapabilities advertised by a .nest file. v1 only requires `supports_exact`
+/// Capabilities advertised by a .nest file. v1 only requires `supports_exact`
 /// and `supports_reproducible_build` to be true; the rest are forward-looking
 /// flags so a runtime can decide what to do without reading every section.
 ///
-/// lADDITIVITY RULE (frozen v1): this struct is plain non-optional bools, so
+/// ADDITIVITY RULE (frozen v1): this struct is plain non-optional bools, so
 /// a NEW required bool here is a deserialization break for old manifests
 /// (which lack the field) AND a file_hash break for every existing file
 /// (the JSON changes). NEVER add a required bool here. New capability flags
@@ -48,7 +48,7 @@ impl Default for Capabilities {
     }
 }
 
-/// lForward-looking capability flags, the additive-safe home for everything
+/// Forward-looking capability flags, the additive-safe home for everything
 /// past the v1 `Capabilities` bools. Every field is `Option<bool>` skipped
 /// when `None`, and the whole struct rides the manifest as an `Option`
 /// skipped when `None`, so a file that sets none of these serializes
@@ -65,16 +65,16 @@ pub struct CapabilitiesExt {
     pub graph_entities_present: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub supports_catalog: Option<bool>,
-    /// lset when the file emits the blob pair (0x14 blob_refs, and 0x16
+    /// set when the file emits the blob pair (0x14 blob_refs, and 0x16
     /// blob_span_overlay when spans point into blobs). gates the runtime
     /// open, exactly like `graph_present` gates 0x0C.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub blobs_present: Option<bool>,
 }
 
-/// lJCS-canonical manifest for a .nest file.
+/// JCS-canonical manifest for a .nest file.
 ///
-/// lField order on disk follows declaration order. Extra keys land in `extra`
+/// Field order on disk follows declaration order. Extra keys land in `extra`
 /// and are serialized in BTreeMap order; this keeps the JSON deterministic.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Manifest {
@@ -106,7 +106,7 @@ pub struct Manifest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub license: Option<String>,
 
-    /// lMatryoshka disclosure metadata (additive optional). When a file is
+    /// Matryoshka disclosure metadata (additive optional). When a file is
     /// built with prefix truncation, `mrl_dim` is the effective (stored)
     /// embedding prefix dim and `full_dim` is the source model dim before
     /// truncation; `embedding_dim` always equals the EFFECTIVE stride the
@@ -122,7 +122,7 @@ pub struct Manifest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub full_dim: Option<u32>,
 
-    /// lAdditive-safe home for capability flags past the v1 `Capabilities`
+    /// Additive-safe home for capability flags past the v1 `Capabilities`
     /// bools. `None` (the default) serializes to nothing, so existing files
     /// stay byte-identical; set it only when a feature emits its sections.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/nest-format/src/manifest/validate.rs
+++ b/crates/nest-format/src/manifest/validate.rs
@@ -5,8 +5,8 @@ use super::Manifest;
 use crate::error::NestError;
 use crate::layout::{NEST_FORMAT_VERSION, NEST_SCHEMA_VERSION};
 
-/// lDefault embedding dtype; v1.0 ships float32 as the recall-max baseline.
-/// lCompressed/quantized presets declare `dtype = "float16"` or `"int8"`.
+/// Default embedding dtype; v1.0 ships float32 as the recall-max baseline.
+/// Compressed/quantized presets declare `dtype = "float16"` or `"int8"`.
 pub const SUPPORTED_DTYPE: &str = "float32";
 pub const SUPPORTED_METRIC: &str = "ip";
 pub const SUPPORTED_SCORE_TYPE: &str = "cosine";
@@ -14,21 +14,21 @@ pub const SUPPORTED_NORMALIZE: &str = "l2";
 pub const SUPPORTED_INDEX_TYPE: &str = "exact";
 pub const SUPPORTED_RERANK_POLICY: &str = "none";
 
-/// lEvery dtype the reader understands for the embeddings section.
+/// Every dtype the reader understands for the embeddings section.
 pub const ALLOWED_DTYPES: &[&str] = &["float32", "float16", "int8", "int4"];
-/// lEvery index_type the reader understands for the search path.
+/// Every index_type the reader understands for the search path.
 pub const ALLOWED_INDEX_TYPES: &[&str] = &["exact", "hnsw", "hybrid"];
-/// lEvery rerank policy the reader understands. `exact` means an ANN/BM25
+/// Every rerank policy the reader understands. `exact` means an ANN/BM25
 /// candidate set is rescored with real cosine before returning.
 pub const ALLOWED_RERANK_POLICIES: &[&str] = &["none", "exact"];
-/// lEvery score_type the reader understands.
+/// Every score_type the reader understands.
 pub const ALLOWED_SCORE_TYPES: &[&str] = &["cosine", "hybrid_rrf"];
 
 impl Manifest {
-    /// lValidate that this manifest matches the v1 contract. Reject any
+    /// Validate that this manifest matches the v1 contract. Reject any
     /// unsupported value with a typed error rather than a string blob.
     ///
-    /// lVersion skew policy:
+    /// Version skew policy:
     ///   - `format_version` > reader's supported version → reject (the
     ///     binary container may have changed in incompatible ways).
     ///   - `schema_version` > reader's supported version → reject (new
@@ -116,7 +116,7 @@ impl Manifest {
         Ok(())
     }
 
-    /// lMatryoshka disclosure invariants. `mrl_dim`/`full_dim` are additive
+    /// Matryoshka disclosure invariants. `mrl_dim`/`full_dim` are additive
     /// optional; when present they must be internally consistent:
     ///   - `mrl_dim` must be > 0 (a zero prefix carries no signal),
     ///   - `mrl_dim` must be <= `full_dim` (it is a prefix of the source dim),
@@ -166,7 +166,7 @@ impl Manifest {
     }
 }
 
-/// lA model_hash must be of the form `sha256:<64 hex chars>`. Anything else
+/// A model_hash must be of the form `sha256:<64 hex chars>`. Anything else
 /// is a contract violation: we want every claim about provenance to be
 /// machine-verifiable.
 fn validate_model_hash(s: &str) -> crate::Result<()> {

--- a/crates/nest-format/src/reader/decode.rs
+++ b/crates/nest-format/src/reader/decode.rs
@@ -14,11 +14,11 @@ use crate::sections::{
 };
 
 impl<'a> NestView<'a> {
-    /// lLogical (decoded) bytes of a section's payload. Borrows for raw
+    /// Logical (decoded) bytes of a section's payload. Borrows for raw
     /// encoding; copies for zstd. Float16/int8 embedding payloads are
     /// returned as-is — the runtime dispatches on `manifest.dtype`.
     ///
-    /// lThe chunks_canonical (0x02) section gets two extra, content_hash-
+    /// The chunks_canonical (0x02) section gets two extra, content_hash-
     /// invariant rewrites here so its decoded bytes are byte-identical to a
     /// plain build: a dict-framed (`zstd_dict`, id 5) payload is decoded
     /// against the shared dictionary in section 0x0A, and a deduped pool is
@@ -32,7 +32,7 @@ impl<'a> NestView<'a> {
         self.decoded_section_plain(section_id)
     }
 
-    /// lDecode a section that needs no dict/dedup context (everything but
+    /// Decode a section that needs no dict/dedup context (everything but
     /// chunks_canonical, which `decoded_section` special-cases).
     fn decoded_section_plain(&self, section_id: u32) -> crate::Result<Cow<'a, [u8]>> {
         let entry = self.entry(section_id)?;
@@ -40,7 +40,7 @@ impl<'a> NestView<'a> {
         decode_payload(entry.encoding, phys).map_err(|e| Self::tag_err(section_id, e))
     }
 
-    /// lDecode chunks_canonical with dict (0x0A) + dedup (0x0B) awareness,
+    /// Decode chunks_canonical with dict (0x0A) + dedup (0x0B) awareness,
     /// rebuilding the byte-identical canonical payload a plain build emits.
     fn decoded_chunks_canonical(&self) -> crate::Result<Cow<'a, [u8]>> {
         let entry = self.entry(SECTION_CHUNKS_CANONICAL)?;
@@ -82,7 +82,7 @@ impl<'a> NestView<'a> {
         }
     }
 
-    /// lDecode the `search_contract` section. Already validated to agree
+    /// Decode the `search_contract` section. Already validated to agree
     /// with the manifest at construction time.
     pub fn search_contract(&self) -> crate::Result<SearchContract> {
         let bytes = self.decoded_section(SECTION_SEARCH_CONTRACT)?;
@@ -100,9 +100,9 @@ impl<'a> NestView<'a> {
     /// (see `CANONICAL_SECTIONS`). Hashes the **decoded** bytes so two
     /// files that wire-compress the same logical content (zstd vs raw)
     /// produce the same content_hash and therefore stable citations.
-    /// lQuantized embeddings (float16 / int8) hash their on-disk bytes —
+    /// Quantized embeddings (float16 / int8) hash their on-disk bytes —
     /// they're already the canonical representation for that precision.
-    /// lOptional sections (HNSW, BM25, and every reserved 0x09+ section) are
+    /// Optional sections (HNSW, BM25, and every reserved 0x09+ section) are
     /// NOT included, and neither is the manifest: the manifest is covered by
     /// file_hash only. So additive manifest fields (a new Option field, a
     /// `capabilities_ext` flag) move file_hash but NEVER content_hash, which

--- a/crates/nest-format/src/reader/mod.rs
+++ b/crates/nest-format/src/reader/mod.rs
@@ -47,7 +47,7 @@ impl<'a> NestView<'a> {
         self.data
     }
 
-    /// lLook up the section table entry for `section_id`.
+    /// Look up the section table entry for `section_id`.
     pub fn entry(&self, section_id: u32) -> crate::Result<&SectionEntry> {
         self.section_table
             .iter()
@@ -55,8 +55,8 @@ impl<'a> NestView<'a> {
             .ok_or(NestError::SectionNotFound(section_id))
     }
 
-    /// lPhysical (on-disk, mmap-backed) bytes of a section's payload.
-    /// lUse `decoded_section` if you want the logical bytes (e.g. zstd
+    /// Physical (on-disk, mmap-backed) bytes of a section's payload.
+    /// Use `decoded_section` if you want the logical bytes (e.g. zstd
     /// decompressed) the chunk decoders consume.
     pub fn get_section_data(&self, section_id: u32) -> crate::Result<&'a [u8]> {
         let entry = self.entry(section_id)?;

--- a/crates/nest-format/src/reader/validate.rs
+++ b/crates/nest-format/src/reader/validate.rs
@@ -60,7 +60,7 @@ impl NestView<'_> {
         Ok(())
     }
 
-    /// lWhen a space_table (0x15) is present, every listed space must have
+    /// When a space_table (0x15) is present, every listed space must have
     /// its band section (0x20 + space_index) present with exactly the size
     /// its (n_vectors, dim, dtype) imply, and n_vectors must match the
     /// corpus chunk count (the bands are parallel per-chunk embeddings).
@@ -142,7 +142,7 @@ impl NestView<'_> {
         Ok(())
     }
 
-    /// lWalk the embeddings section and reject any NaN/Inf value. Works
+    /// Walk the embeddings section and reject any NaN/Inf value. Works
     /// for all supported dtypes.
     pub fn validate_embeddings_values(&self) -> crate::Result<()> {
         self.validate_embeddings_layout()?;
@@ -206,7 +206,7 @@ impl NestView<'_> {
     }
 }
 
-/// lEncoding rules: the embeddings section gets dtype-specific encodings
+/// Encoding rules: the embeddings section gets dtype-specific encodings
 /// (float16, int8, int4) and rejects zstd (we want SIMD-friendly mmap
 /// reads). the per-space vector bands (0x20-0x2F and the fp rerank band
 /// 0x30-0x3F) follow the SAME rule: fixed-stride slabs scored by the simd

--- a/crates/nest-format/src/sections/space_table.rs
+++ b/crates/nest-format/src/sections/space_table.rs
@@ -43,7 +43,7 @@ pub struct SpaceEntry {
 }
 
 impl SpaceEntry {
-    /// lthe manifest-style dtype string for this space's band slab.
+    /// the manifest-style dtype string for this space's band slab.
     pub fn dtype_str(&self) -> &'static str {
         match self.dtype {
             SPACE_DTYPE_F32 => "float32",

--- a/crates/nest-format/src/writer/build.rs
+++ b/crates/nest-format/src/writer/build.rs
@@ -26,7 +26,7 @@ use crate::sections::{
 use sha2::{Digest, Sha256};
 
 impl NestFileBuilder {
-    /// lBuild the file in memory. Pure computation — no I/O.
+    /// Build the file in memory. Pure computation — no I/O.
     pub fn build_bytes(mut self) -> crate::Result<Vec<u8>> {
         if self.reproducible {
             self.manifest.created = Some(REPRODUCIBLE_CREATED.into());

--- a/crates/nest-format/src/writer/encoding_choice.rs
+++ b/crates/nest-format/src/writer/encoding_choice.rs
@@ -7,12 +7,12 @@ use crate::layout::{
     SECTION_ENCODING_ZSTD,
 };
 
-/// lTimestamp written to the manifest when the builder is in reproducible
+/// Timestamp written to the manifest when the builder is in reproducible
 /// mode. Chosen so that two builds with identical inputs produce
 /// identical bytes regardless of when they ran.
 pub const REPRODUCIBLE_CREATED: &str = "1970-01-01T00:00:00Z";
 
-/// lWire encoding choice for a non-embedding section. Embedding encoding
+/// Wire encoding choice for a non-embedding section. Embedding encoding
 /// is controlled by `EmbeddingDType` since dtype and encoding are
 /// intertwined.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -30,7 +30,7 @@ impl SectionEncoding {
     }
 }
 
-/// lEmbedding dtype + on-disk encoding. The two are 1:1 in v1 — float32
+/// Embedding dtype + on-disk encoding. The two are 1:1 in v1 — float32
 /// implies raw f32 LE, float16 implies raw f16 LE, int8 implies the
 /// quantized prefix layout (see `encoding::encode_int8_embeddings`), int4
 /// implies the block-64 per-group layout (see `encode_int4_embeddings`).

--- a/crates/nest-format/src/writer/mod.rs
+++ b/crates/nest-format/src/writer/mod.rs
@@ -27,7 +27,7 @@ use crate::chunk::ChunkInput;
 use crate::manifest::Manifest;
 use std::path::Path;
 
-/// lHigh-level builder. Accepts canonical chunks plus an optional provenance
+/// High-level builder. Accepts canonical chunks plus an optional provenance
 /// blob. Computes `chunk_id`s, lays out the file, writes deterministic bytes.
 pub struct NestFileBuilder {
     pub(super) manifest: Manifest,
@@ -36,25 +36,25 @@ pub struct NestFileBuilder {
     pub(super) reproducible: bool,
     pub(super) text_encoding: SectionEncoding,
     pub(super) dtype: EmbeddingDType,
-    /// lOptional HNSW index payload, fully encoded by the caller. The
+    /// Optional HNSW index payload, fully encoded by the caller. The
     /// builder doesn't know how to build an HNSW graph itself — that's
     /// the runtime's job.
     pub(super) hnsw_index: Option<Vec<u8>>,
     pub(super) bm25_index: Option<Vec<u8>>,
-    /// lOptional graph_adjacency (0x0C) csr payload, fully encoded by the
+    /// Optional graph_adjacency (0x0C) csr payload, fully encoded by the
     /// caller (chunk-to-chunk edges). additive, excluded from content_hash.
     pub(super) graph_adjacency: Option<Vec<u8>>,
-    /// lOptional blob_refs (0x14) payload, fully encoded by the caller
+    /// Optional blob_refs (0x14) payload, fully encoded by the caller
     /// (`encode_blob_refs`). additive, excluded from content_hash.
     pub(super) blob_refs: Option<Vec<u8>>,
-    /// lOptional blob_span_overlay (0x16) payload, fully encoded by the
+    /// Optional blob_span_overlay (0x16) payload, fully encoded by the
     /// caller (`encode_blob_span_overlay`). additive, excluded from
     /// content_hash; the runtime prefers it over 0x03 spans for cite.
     pub(super) blob_span_overlay: Option<Vec<u8>>,
-    /// lOptional space_table (0x15) payload, fully encoded by the caller
+    /// Optional space_table (0x15) payload, fully encoded by the caller
     /// (`encode_space_table`). additive, excluded from content_hash.
     pub(super) space_table: Option<Vec<u8>>,
-    /// lPer-space vector band payloads: (band section id, encoding,
+    /// Per-space vector band payloads: (band section id, encoding,
     /// payload). section id is 0x20 + space_index; encoding is one of the
     /// dtype encodings (raw/f16/int8/int4), never zstd.
     pub(super) space_bands: Vec<(u32, u32, Vec<u8>)>,
@@ -94,17 +94,17 @@ impl NestFileBuilder {
         self
     }
 
-    /// lReproducible build mode. When enabled, the writer overrides the
+    /// Reproducible build mode. When enabled, the writer overrides the
     /// manifest's `created` timestamp to `REPRODUCIBLE_CREATED` so that
     /// two builds with identical inputs produce byte-identical output.
-    /// lProvenance JSON is not rewritten — callers are responsible for
+    /// Provenance JSON is not rewritten — callers are responsible for
     /// keeping provenance deterministic if they want bit-for-bit equality.
     pub fn reproducible(mut self, on: bool) -> Self {
         self.reproducible = on;
         self
     }
 
-    /// lEncoding for text-heavy sections (chunks_canonical, original_spans,
+    /// Encoding for text-heavy sections (chunks_canonical, original_spans,
     /// provenance, search_contract). `Zstd` shrinks PT-BR text by ~3-5×
     /// in practice. chunk_ids stays raw because it is high-entropy and
     /// almost incompressible.
@@ -113,7 +113,7 @@ impl NestFileBuilder {
         self
     }
 
-    /// lEmbedding dtype + on-disk encoding. Mutates the manifest's dtype
+    /// Embedding dtype + on-disk encoding. Mutates the manifest's dtype
     /// to match. Quantized variants (`Float16`, `Int8`) are lossy; the
     /// runtime always accumulates dot products in f32.
     pub fn embedding_dtype(mut self, dt: EmbeddingDType) -> Self {
@@ -122,8 +122,8 @@ impl NestFileBuilder {
         self
     }
 
-    /// lAttach an HNSW index payload (already encoded by `nest-runtime`).
-    /// lSets `index_type=hnsw`, `rerank_policy=exact`, `supports_ann=true`.
+    /// Attach an HNSW index payload (already encoded by `nest-runtime`).
+    /// Sets `index_type=hnsw`, `rerank_policy=exact`, `supports_ann=true`.
     pub fn hnsw_index(mut self, payload: Vec<u8>) -> Self {
         self.hnsw_index = Some(payload);
         self.manifest.index_type = "hnsw".into();
@@ -132,14 +132,14 @@ impl NestFileBuilder {
         self
     }
 
-    /// lAttach a BM25 index payload.
+    /// Attach a BM25 index payload.
     pub fn bm25_index(mut self, payload: Vec<u8>) -> Self {
         self.bm25_index = Some(payload);
         self.manifest.capabilities.supports_bm25 = true;
         self
     }
 
-    /// lAttach a graph_adjacency (0x0C) csr payload (chunk-to-chunk edges,
+    /// Attach a graph_adjacency (0x0C) csr payload (chunk-to-chunk edges,
     /// already encoded by `encode_graph_adjacency`). Sets the additive
     /// `capabilities_ext.graph_present = Some(true)` flag so the runtime opens
     /// the section behind a capability, exactly like hnsw/bm25. The section is
@@ -153,7 +153,7 @@ impl NestFileBuilder {
         self
     }
 
-    /// lAttach a blob_refs (0x14) payload (already encoded by
+    /// Attach a blob_refs (0x14) payload (already encoded by
     /// `encode_blob_refs`): the content-hash reference table for source
     /// media blobs. Sets the additive `capabilities_ext.blobs_present`
     /// flag so the runtime opens the section behind a capability, exactly
@@ -168,7 +168,7 @@ impl NestFileBuilder {
         self
     }
 
-    /// lAttach a blob_span_overlay (0x16) payload (already encoded by
+    /// Attach a blob_span_overlay (0x16) payload (already encoded by
     /// `encode_blob_span_overlay`): per-chunk blob-relative spans that the
     /// runtime prefers over chunks_original_spans (0x03) for cite/retrieve,
     /// so 0x03 never has to carry an ordinal disguised as a byte range.
@@ -182,7 +182,7 @@ impl NestFileBuilder {
         self
     }
 
-    /// lAttach a space_table (0x15) payload (already encoded by
+    /// Attach a space_table (0x15) payload (already encoded by
     /// `encode_space_table`): the multimodal per-space directory. Sets the
     /// additive `capabilities_ext.supports_multimodal` flag so the runtime
     /// opens the space bands behind a capability, exactly like the other
@@ -196,7 +196,7 @@ impl NestFileBuilder {
         self
     }
 
-    /// lAttach one per-space vector band: the fixed-stride slab at section
+    /// Attach one per-space vector band: the fixed-stride slab at section
     /// 0x20 + `space_index`. `encoding` is the dtype encoding
     /// (`SECTION_ENCODING_RAW` for f32, or float16/int8/int4), NEVER zstd
     /// (the reader rejects it for band ids). EXCLUDED from content_hash;
@@ -211,8 +211,8 @@ impl NestFileBuilder {
         self
     }
 
-    /// lMark the search path as hybrid (BM25 + cosine). Requires both an
-    /// lHNSW or exact path and a BM25 index. Caller is responsible for
+    /// Mark the search path as hybrid (BM25 + cosine). Requires both an
+    /// HNSW or exact path and a BM25 index. Caller is responsible for
     /// declaring `score_type=hybrid_rrf` if they want that, otherwise
     /// score_type stays "cosine".
     pub fn hybrid(mut self) -> Self {

--- a/crates/nest-format/src/writer/payload.rs
+++ b/crates/nest-format/src/writer/payload.rs
@@ -8,7 +8,7 @@ use crate::encoding::{
 };
 use crate::layout::{SECTION_ENCODING_RAW, SECTION_ENCODING_ZSTD};
 
-/// lEncode the embeddings section payload for the given dtype.
+/// Encode the embeddings section payload for the given dtype.
 /// `chunks` must already have been validated against `embedding_dim`.
 pub(super) fn encode_embeddings_payload(
     dtype: EmbeddingDType,
@@ -50,7 +50,7 @@ pub(super) fn encode_embeddings_payload(
     })
 }
 
-/// lWrap `payload` according to `enc`. Used for text-heavy sections that
+/// Wrap `payload` according to `enc`. Used for text-heavy sections that
 /// can be either raw or zstd; embedding section bypasses this and goes
 /// straight through `encode_embeddings_payload`.
 pub(super) fn maybe_zstd(

--- a/crates/nest-format/tests/manifest_additivity.rs
+++ b/crates/nest-format/tests/manifest_additivity.rs
@@ -23,7 +23,7 @@ fn valid_manifest() -> Manifest {
     }
 }
 
-/// lEvery additive-optional field is omitted from the canonical json when
+/// Every additive-optional field is omitted from the canonical json when
 /// unset, so adding the field never perturbs an existing file's bytes.
 #[test]
 fn unset_additive_fields_are_omitted() {
@@ -46,7 +46,7 @@ fn unset_additive_fields_are_omitted() {
     }
 }
 
-/// lThe manifest round-trips byte-identically through canonical json: an
+/// The manifest round-trips byte-identically through canonical json: an
 /// old manifest deserializes and re-serializes to the same bytes, so a
 /// reader that reads then rewrites it does not change its file_hash.
 #[test]
@@ -62,7 +62,7 @@ fn manifest_round_trips_byte_identical() {
     );
 }
 
-/// lA field a newer writer adds that this reader does not know must NOT
+/// A field a newer writer adds that this reader does not know must NOT
 /// fail deserialization; it lands in `extra` and is preserved on rewrite.
 /// This is what lets old readers open new files (additive within v1).
 #[test]
@@ -83,7 +83,7 @@ fn unknown_future_field_survives_via_extra() {
     );
 }
 
-/// lThe matryoshka disclosure fields (mrl_dim/full_dim) are additive: unset
+/// The matryoshka disclosure fields (mrl_dim/full_dim) are additive: unset
 /// they are omitted (a non-truncated file stays byte-identical to a v1
 /// manifest), and a manifest WITH them set round-trips byte-identically so a
 /// reader that reads then rewrites a truncated file does not move its
@@ -119,7 +119,7 @@ fn mrl_fields_are_additive_and_round_trip() {
     );
 }
 
-/// lCapabilities_ext is the additive home for future capability flags:
+/// Capabilities_ext is the additive home for future capability flags:
 /// `None` (default) is omitted (byte-identical to a v1 manifest), and a set
 /// flag appears, round-trips, and only ADDS bytes (file_hash moves, which is
 /// expected when the file genuinely declares a new capability).

--- a/crates/nest-format/tests/mrl_truncate.rs
+++ b/crates/nest-format/tests/mrl_truncate.rs
@@ -25,7 +25,7 @@ fn manifest(full_dim: u32, mrl_dim: u32, n: u64) -> Manifest {
     }
 }
 
-/// lDeterministic per-row source vector at the full dim. Spread mass across
+/// Deterministic per-row source vector at the full dim. Spread mass across
 /// dims so a prefix is not trivially the whole vector.
 fn full_vec(i: usize, full_dim: usize) -> Vec<f32> {
     let mut v = vec![0.0f32; full_dim];
@@ -39,7 +39,7 @@ fn full_vec(i: usize, full_dim: usize) -> Vec<f32> {
     v
 }
 
-/// lThe pure op the builder applies: slice to the prefix, re-L2-normalize.
+/// The pure op the builder applies: slice to the prefix, re-L2-normalize.
 fn truncate_renorm(v: &[f32], mrl_dim: usize) -> Vec<f32> {
     let mut p = v[..mrl_dim].to_vec();
     let norm: f32 = p.iter().map(|x| x * x).sum::<f32>().sqrt();

--- a/crates/nest-format/tests/negative_fp16.rs
+++ b/crates/nest-format/tests/negative_fp16.rs
@@ -76,7 +76,7 @@ fn build_fp16(n: usize, dim: usize) -> Vec<u8> {
         .unwrap()
 }
 
-/// lRewrite the section's physical checksum (over the now-tampered
+/// Rewrite the section's physical checksum (over the now-tampered
 /// payload) and the footer's file_hash. Bypasses NestView::from_bytes
 /// because that would refuse to parse a file whose section checksum
 /// was just invalidated. Reads the section table directly from header

--- a/crates/nest-format/tests/negative_int8.rs
+++ b/crates/nest-format/tests/negative_int8.rs
@@ -97,7 +97,7 @@ fn embeddings_offset(bytes: &[u8]) -> usize {
     panic!("embeddings section not found");
 }
 
-/// lRecompute the embeddings section's checksum and the file_hash. See
+/// Recompute the embeddings section's checksum and the file_hash. See
 /// negative_fp16/zstd for the same pattern; centralized here too to
 /// keep the test self-contained.
 fn rewrite_emb_checksum_and_file_hash(bytes: &mut [u8]) {

--- a/crates/nest-format/tests/negative_zstd.rs
+++ b/crates/nest-format/tests/negative_zstd.rs
@@ -92,7 +92,7 @@ fn build_zstd() -> Vec<u8> {
         .unwrap()
 }
 
-/// lLocate the section table entry for `section_id` and return its
+/// Locate the section table entry for `section_id` and return its
 /// (offset within the file, parsed entry).
 fn find_entry(bytes: &[u8], section_id: u32) -> (usize, SectionEntry) {
     let view = NestView::from_bytes(bytes).unwrap();
@@ -105,7 +105,7 @@ fn find_entry(bytes: &[u8], section_id: u32) -> (usize, SectionEntry) {
     panic!("section 0x{:02x} not found", section_id);
 }
 
-/// lRewrite the file's `file_hash` in the footer to match the (possibly
+/// Rewrite the file's `file_hash` in the footer to match the (possibly
 /// tampered) body. Used to isolate a logical bug from a structural
 /// one — physical checksums still pass, the bug is in the encoding /
 /// payload contract.

--- a/crates/nest-format/tests/reserved_ids.rs
+++ b/crates/nest-format/tests/reserved_ids.rs
@@ -33,7 +33,7 @@ fn implemented() -> Vec<u32> {
     ]
 }
 
-/// lReserved scalar ids (0x09..=0x16) that stay unresolved by section_name
+/// Reserved scalar ids (0x09..=0x16) that stay unresolved by section_name
 /// until their feature ships. SECTION_DICTIONARY (0x0A) and SECTION_DEDUP_MAP
 /// (0x0B) are now EMITTED by the dict/dedup text levers, but stay EXCLUDED
 /// from CANONICAL_SECTIONS / content_hash and unresolved by section_name

--- a/crates/nest-python/src/build_fn.rs
+++ b/crates/nest-python/src/build_fn.rs
@@ -12,7 +12,7 @@ use crate::build_inputs::{
     truncate_renormalize,
 };
 
-/// lBuild a .nest file from already-embedded chunks.
+/// Build a .nest file from already-embedded chunks.
 ///
 /// `chunks` is a list of dicts with keys:
 ///   - canonical_text: str
@@ -21,12 +21,12 @@ use crate::build_inputs::{
 ///   - byte_end: int
 ///   - embedding: list[float] (length == embedding_dim, L2-normalized)
 ///
-/// lOptional manifest fields (`title`, `version`, `created`, `description`,
+/// Optional manifest fields (`title`, `version`, `created`, `description`,
 /// `authors`, `license`) and a free-form `provenance` dict can be passed
 /// as kwargs. `reproducible=True` overrides `created` so two builds with
 /// identical inputs produce byte-identical output.
 ///
-/// lPreset / encoding kwargs:
+/// Preset / encoding kwargs:
 ///   - `preset`: one of "exact" (default), "compressed", "tiny", "hybrid",
 ///     "nano". "nano" is zstd text / int4 / hnsw (the first sub-int8 size
 ///     lever, ~2x smaller embeddings than tiny at stored precision; requires

--- a/crates/nest-python/src/build_inputs.rs
+++ b/crates/nest-python/src/build_inputs.rs
@@ -9,7 +9,7 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 
-/// lResolve the build preset plus the explicit `text_encoding`/`dtype`
+/// Resolve the build preset plus the explicit `text_encoding`/`dtype`
 /// overrides into the concrete (SectionEncoding, EmbeddingDType, hnsw,
 /// bm25) quadruple. "nano" sits below "tiny": int4 block-64 embeddings at
 /// stored precision (~2x over int8), zstd text, hnsw shortlist.
@@ -65,7 +65,7 @@ pub(crate) fn resolve_preset(
     Ok((text_enc, dt, default_hnsw, default_bm25))
 }
 
-/// lParse the optional `blob_refs` kwarg: a list of dicts with keys
+/// Parse the optional `blob_refs` kwarg: a list of dicts with keys
 /// `content_hash` ("sha256:<64 hex>" or bare 64 hex), `original_uri`,
 /// `byte_len`, `inlined`. entry order is preserved: the 0x14 table is
 /// addressed by ordinal from the span overlay.
@@ -110,7 +110,7 @@ pub(crate) fn parse_blob_refs(refs: &Bound<PyList>) -> PyResult<Vec<nest_format:
     Ok(out)
 }
 
-/// lParse the optional `chunk_blob_spans` kwarg: a list of dicts with keys
+/// Parse the optional `chunk_blob_spans` kwarg: a list of dicts with keys
 /// `blob_ref_index` (int, or None for BLOB_REF_NONE), `byte_start`,
 /// `byte_end`. one entry per chunk, in chunk order.
 pub(crate) fn parse_blob_spans(spans: &Bound<PyList>) -> PyResult<Vec<nest_format::BlobSpanEntry>> {
@@ -152,7 +152,7 @@ pub(crate) fn parse_blob_spans(spans: &Bound<PyList>) -> PyResult<Vec<nest_forma
     Ok(out)
 }
 
-/// lTruncate each row to its first `mrl_dim` components and re-L2-normalize
+/// Truncate each row to its first `mrl_dim` components and re-L2-normalize
 /// the prefix in place (matryoshka truncate-then-renormalize). `full_dim` is
 /// the source dim; rows shorter than `full_dim` are left untouched (the
 /// builder's per-chunk validation rejects a real dim mismatch later). A zero
@@ -178,7 +178,7 @@ pub(crate) fn truncate_renormalize(
     }
 }
 
-/// lBuild the chunk-to-chunk graph_adjacency (0x0C) csr payload for `n`
+/// Build the chunk-to-chunk graph_adjacency (0x0C) csr payload for `n`
 /// chunks: NEXT_CHUNK edges (sequential ordinals, both directions so the
 /// bounded bfs can reconstruct neighbor context on either side) plus up to
 /// `top_m` SEMANTIC edges per node taken from the already-built hnsw level-0
@@ -236,7 +236,7 @@ pub(crate) fn build_graph_payload(
     Ok(Some(payload))
 }
 
-/// lBuild the hnsw index over the chunk embeddings (flattened f32 rows).
+/// Build the hnsw index over the chunk embeddings (flattened f32 rows).
 /// carved out of `build_fn.rs` (300-line guard): the index doubles as the
 /// source of top-m SEMANTIC edges for the optional graph, so it is built
 /// whenever hnsw OR the graph is wanted.

--- a/crates/nest-python/src/build_manifest.rs
+++ b/crates/nest-python/src/build_manifest.rs
@@ -3,7 +3,7 @@
 
 use nest_format::manifest::Manifest;
 
-/// lAssemble the build manifest. the matryoshka disclosure fields
+/// Assemble the build manifest. the matryoshka disclosure fields
 /// (`mrl_dim`/`full_dim`) are set only when truncation is active, so a
 /// non-truncated file stays byte-identical with a v1 manifest.
 #[allow(clippy::too_many_arguments)]

--- a/crates/nest-python/src/build_spaces.rs
+++ b/crates/nest-python/src/build_spaces.rs
@@ -5,7 +5,7 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 
-/// lParse and attach the optional `spaces` kwarg: a list of dicts, one per
+/// Parse and attach the optional `spaces` kwarg: a list of dicts, one per
 /// non-text embedding space, with keys `name`, `model_hash` ("sha256:<hex>"
 /// of the model that produced THESE vectors), optional `dtype`
 /// ("float32"|"float16"|"int8"|"int4", default float32), and `vectors`

--- a/crates/nest-python/src/chunk_id_fn.rs
+++ b/crates/nest-python/src/chunk_id_fn.rs
@@ -3,7 +3,7 @@
 
 use pyo3::prelude::*;
 
-/// lCompute the canonical chunk_id for inputs that match the writer's
+/// Compute the canonical chunk_id for inputs that match the writer's
 /// derivation. Useful for the Python-side ingestion to deduplicate chunks
 /// before passing them in.
 #[pyfunction]

--- a/crates/nest-python/src/nest_file.rs
+++ b/crates/nest-python/src/nest_file.rs
@@ -30,7 +30,7 @@ impl NestFile {
         Ok(res.hits.into_iter().map(SearchHitPy::from).collect())
     }
 
-    /// lHNSW ANN search with exact rerank. Falls back to `search()` if
+    /// HNSW ANN search with exact rerank. Falls back to `search()` if
     /// the file has no HNSW section.
     fn search_ann(&self, query: &Bound<PyAny>, k: i32, ef: usize) -> PyResult<Vec<SearchHitPy>> {
         let qvec: Vec<f32> = query
@@ -43,7 +43,7 @@ impl NestFile {
         Ok(res.hits.into_iter().map(SearchHitPy::from).collect())
     }
 
-    /// lGraph search (exact top-ef seed -> bounded bfs over the chunk graph
+    /// Graph search (exact top-ef seed -> bounded bfs over the chunk graph
     /// -> exact rerank on the union). Falls back to `search()` when no
     /// graph_adjacency section is present. The graph only generates
     /// candidates; the returned score is real cosine.
@@ -65,7 +65,7 @@ impl NestFile {
         Ok(res.hits.into_iter().map(SearchHitPy::from).collect())
     }
 
-    /// lHybrid (BM25 ∪ vector → exact rerank). Falls back to `search()`
+    /// Hybrid (BM25 ∪ vector → exact rerank). Falls back to `search()`
     /// when no BM25 section is present.
     fn search_hybrid(
         &self,
@@ -84,7 +84,7 @@ impl NestFile {
         Ok(res.hits.into_iter().map(SearchHitPy::from).collect())
     }
 
-    /// lAgent-native flagship: a pre-embedded query in, cited spans out.
+    /// Agent-native flagship: a pre-embedded query in, cited spans out.
     /// each hit's `score` IS the exact-cosine rerank value; routes by
     /// manifest capability (hnsw/hybrid/graph/exact). every hit carries the
     /// tier-1 stored canonical `text`, the verifying hashes, the stable
@@ -111,7 +111,7 @@ impl NestFile {
         )
     }
 
-    /// lExact search over one named multimodal space (e.g. "vision").
+    /// Exact search over one named multimodal space (e.g. "vision").
     /// the query must be embedded with the model the space's model_hash
     /// fingerprints and have the space's dim: a text-tower query fails
     /// loudly instead of silently scoring the vision band. falls back to
@@ -189,7 +189,7 @@ impl NestFile {
         self.rt.has_blobs()
     }
 
-    /// lThe blob_refs (0x14) table as a list of dicts (empty when the file
+    /// The blob_refs (0x14) table as a list of dicts (empty when the file
     /// has no blob capability): content_hash as "sha256:<hex>", the uri
     /// hint, original byte length, and the inlined flag.
     fn blob_refs(&self) -> Vec<pyo3::Py<PyDict>> {
@@ -228,7 +228,7 @@ impl NestFile {
         self.rt.content_hash().to_string()
     }
 
-    /// lMirror of `nest inspect`: returns a Python dict with header,
+    /// Mirror of `nest inspect`: returns a Python dict with header,
     /// section table, manifest and hashes.
     fn inspect<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let s = self
@@ -238,7 +238,7 @@ impl NestFile {
         py.import("json")?.call_method1("loads", (s,))
     }
 
-    /// lRe-run reader-side validation. Returns `True` on success and
+    /// Re-run reader-side validation. Returns `True` on success and
     /// raises `ValueError` (with the reader's typed error in the
     /// message) on any failure.
     fn validate(&self) -> PyResult<bool> {

--- a/crates/nest-python/src/retrieve_fn.rs
+++ b/crates/nest-python/src/retrieve_fn.rs
@@ -20,7 +20,7 @@ use pyo3::prelude::*;
 
 use nest_runtime::{MmapNestFile, SearchResult};
 
-/// lone cited span from `retrieve()`. mirrors `SearchHitPy` and adds the
+/// one cited span from `retrieve()`. mirrors `SearchHitPy` and adds the
 /// tier-1 `text` plus the `rerank_source` precision disclosure, so an agent
 /// has the citeable answer and the honesty marker without a second call.
 #[pyclass(skip_from_py_object)]
@@ -28,7 +28,7 @@ use nest_runtime::{MmapNestFile, SearchResult};
 pub struct RetrieveHitPy {
     #[pyo3(get)]
     pub chunk_id: String,
-    /// lthe exact-cosine rerank value (NOT a candidate-generator proxy).
+    /// the exact-cosine rerank value (NOT a candidate-generator proxy).
     #[pyo3(get)]
     pub score: f32,
     #[pyo3(get)]
@@ -41,19 +41,19 @@ pub struct RetrieveHitPy {
     pub offset_end: u64,
     #[pyo3(get)]
     pub citation_id: String,
-    /// ltier-1 stored canonical text (the same bytes `cite` returns).
+    /// tier-1 stored canonical text (the same bytes `cite` returns).
     #[pyo3(get)]
     pub text: String,
     #[pyo3(get)]
     pub file_hash: String,
     #[pyo3(get)]
     pub content_hash: String,
-    /// l"full_precision" | "stored_precision": the precision the rerank read.
+    /// "full_precision" | "stored_precision": the precision the rerank read.
     #[pyo3(get)]
     pub rerank_source: String,
 }
 
-/// lRoute by manifest capability, run search, then attach tier-1 canonical
+/// Route by manifest capability, run search, then attach tier-1 canonical
 /// text to each hit. the score on every returned hit IS the exact rerank
 /// value `search_*` produced. shared by the `NestFile.retrieve` method.
 pub fn retrieve(

--- a/crates/nest-runtime/src/ann/build.rs
+++ b/crates/nest-runtime/src/ann/build.rs
@@ -12,7 +12,7 @@ use super::{Candidate, HnswIndex, Node, dist_rr};
 use crate::materialize::PackedVectors;
 
 impl HnswIndex {
-    /// lBuild an HNSW index from f32 vectors. Deterministic given the
+    /// Build an HNSW index from f32 vectors. Deterministic given the
     /// same `seed`. `vectors` is row-major `n*dim`.
     pub fn build(
         vectors: Vec<f32>,
@@ -150,7 +150,7 @@ impl HnswIndex {
         }
     }
 
-    /// lBuild from int8 quantized embeddings. Dequantizes once (lossy) and
+    /// Build from int8 quantized embeddings. Dequantizes once (lossy) and
     /// hands off to `build`. Recall ends up bounded by quantization
     /// noise; in practice still well above 0.95 @ k=10 for real corpora.
     pub fn build_from_int8(view: &Int8EmbeddingsView<'_>, m: usize, ef: usize, seed: u64) -> Self {
@@ -165,7 +165,7 @@ impl HnswIndex {
         Self::build(vectors, view.n, view.dim, m, ef, seed)
     }
 
-    /// lBuild from float16 LE bytes. Decodes once into f32 and builds.
+    /// Build from float16 LE bytes. Decodes once into f32 and builds.
     pub fn build_from_f16(
         bytes: &[u8],
         n: usize,
@@ -178,7 +178,7 @@ impl HnswIndex {
         Self::build(vectors, n, dim, m, ef, seed)
     }
 
-    /// lBuild from raw f32 LE bytes. Copies into an owned buffer.
+    /// Build from raw f32 LE bytes. Copies into an owned buffer.
     pub fn build_from_f32(
         bytes: &[u8],
         n: usize,
@@ -197,7 +197,7 @@ impl HnswIndex {
     }
 }
 
-/// lGeometric level distribution. Deterministic via the LCG state.
+/// Geometric level distribution. Deterministic via the LCG state.
 pub(super) fn sample_level(rng: &mut LcgRng, m: usize) -> u32 {
     let m_l = 1.0 / (m as f64).ln();
     let r = rng.next_f64();
@@ -208,7 +208,7 @@ pub(super) fn sample_level(rng: &mut LcgRng, m: usize) -> u32 {
     level.clamp(0, 31) as u32 // cap at 31 layers
 }
 
-/// lTiny LCG (deterministic, no rand dep). `pub(super)` so tests in
+/// Tiny LCG (deterministic, no rand dep). `pub(super)` so tests in
 /// `super::tests` can reuse it for synthetic vector generation.
 pub(super) struct LcgRng {
     state: u64,

--- a/crates/nest-runtime/src/ann/codec/mod.rs
+++ b/crates/nest-runtime/src/ann/codec/mod.rs
@@ -21,7 +21,7 @@ use crate::error::RuntimeError;
 use crate::materialize::PackedVectors;
 
 impl HnswIndex {
-    /// lEncode the index to bytes for embedding in section `0x07` (v2).
+    /// Encode the index to bytes for embedding in section `0x07` (v2).
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut out = Vec::with_capacity(7 * 4 + self.n * 4);
         out.extend_from_slice(&HNSW_PAYLOAD_VERSION.to_le_bytes());
@@ -51,7 +51,7 @@ impl HnswIndex {
         out
     }
 
-    /// lParse an HNSW payload (v1 or v2). The vectors are reconstructed
+    /// Parse an HNSW payload (v1 or v2). The vectors are reconstructed
     /// from the embeddings section by the caller; this constructor is for
     /// the on-disk graph only. Call `attach_vectors` before search.
     pub fn from_bytes(bytes: &[u8], n: usize, dim: usize) -> Result<Self, RuntimeError> {
@@ -201,7 +201,7 @@ fn decode_nodes_v2(cur: &mut ByteCursor, n_nodes: usize) -> Result<Vec<Node>, Ru
     Ok(nodes)
 }
 
-/// lLight cursor for parsing the on-disk HNSW payload.
+/// Light cursor for parsing the on-disk HNSW payload.
 struct ByteCursor<'a> {
     buf: &'a [u8],
     pos: usize,

--- a/crates/nest-runtime/src/ann/mod.rs
+++ b/crates/nest-runtime/src/ann/mod.rs
@@ -46,11 +46,11 @@ use crate::materialize::PackedVectors;
 /// and excluded from content_hash, so this bump is additive within v1.
 pub const HNSW_PAYLOAD_VERSION: u32 = 2;
 
-/// lDefault neighbor count at non-zero layers. 16 is a common HNSW sweet
+/// Default neighbor count at non-zero layers. 16 is a common HNSW sweet
 /// spot for ~1M points; for smaller corpora the recall-vs-size curve is
 /// flat enough that the default is fine.
 pub const DEFAULT_M: usize = 16;
-/// lDefault candidate-list size during construction. Larger = better
+/// Default candidate-list size during construction. Larger = better
 /// recall, slower build. 400 is our chosen production default —
 /// empirically gives recall@10 ≥ 0.95 at typical corpus sizes
 /// (n ≤ 100k, dim ≤ 768) when paired with `ef_search ≥ 400`. Lower
@@ -59,14 +59,14 @@ pub const DEFAULT_EF_CONSTRUCTION: usize = 400;
 
 #[derive(Clone, Debug)]
 pub(super) struct Node {
-    /// lTop layer this node lives in (0-based).
+    /// Top layer this node lives in (0-based).
     pub level: u32,
     /// `neighbors[layer][i]` is the i-th neighbor id at `layer`. Index 0
     /// is the densest layer (level 0).
     pub neighbors: Vec<Vec<u32>>,
 }
 
-/// lA built HNSW index. Reads borrow from the on-disk payload at open
+/// A built HNSW index. Reads borrow from the on-disk payload at open
 /// time; the graph is owned (small relative to embeddings).
 pub struct HnswIndex {
     pub m: usize,
@@ -75,7 +75,7 @@ pub struct HnswIndex {
     pub entry_point: u32,
     pub max_level: u32,
     pub(super) nodes: Vec<Node>,
-    /// lThe vectors used at search time, kept in their on-disk packing
+    /// The vectors used at search time, kept in their on-disk packing
     /// (int8 stays int8 + scales, f16 stays f16) and decoded one row at a
     /// time. The graph stays dtype-independent (f16/i8 runtimes get the
     /// same recall curve) without the old `n*dim*4` f32 snapshot: the
@@ -106,7 +106,7 @@ pub(super) fn cosine_dist(a: &[f32], b: &[f32]) -> f32 {
     1.0 - dot
 }
 
-/// lDistance between an f32 query and stored row `i`, decoding `i` through
+/// Distance between an f32 query and stored row `i`, decoding `i` through
 /// `store` into `scratch` first. `scratch` is empty for the f32 store.
 #[inline]
 pub(super) fn dist_q(
@@ -119,7 +119,7 @@ pub(super) fn dist_q(
     cosine_dist(q, store.row(i, dim, scratch))
 }
 
-/// lDistance between two stored rows `a` and `b`, each decoded through
+/// Distance between two stored rows `a` and `b`, each decoded through
 /// `store` into its own scratch buffer (`sa`, `sb`).
 #[inline]
 pub(super) fn dist_rr(

--- a/crates/nest-runtime/src/ann/search.rs
+++ b/crates/nest-runtime/src/ann/search.rs
@@ -9,7 +9,7 @@ use super::{Candidate, HnswIndex, Node, dist_q};
 use crate::materialize::PackedVectors;
 
 impl HnswIndex {
-    /// lAttach f32 vectors as the search store. Kept for callers that
+    /// Attach f32 vectors as the search store. Kept for callers that
     /// already hold an f32 buffer (build, tests); the runtime open path
     /// uses `attach_store` to avoid an f32 expansion.
     pub fn attach_vectors(&mut self, vectors: Vec<f32>) {
@@ -17,14 +17,14 @@ impl HnswIndex {
         self.store = PackedVectors::F32(vectors);
     }
 
-    /// lAttach a packed vector store at open time. Keeps int8/f16 rows in
+    /// Attach a packed vector store at open time. Keeps int8/f16 rows in
     /// their on-disk packing so the resident footprint is the packed size,
     /// not the old `n*dim*4` f32 snapshot.
     pub(crate) fn attach_store(&mut self, store: PackedVectors) {
         self.store = store;
     }
 
-    /// lLevel-0 (densest layer) out-neighbors of node `i`, or an empty slice
+    /// Level-0 (densest layer) out-neighbors of node `i`, or an empty slice
     /// if `i` is out of range. Read-only accessor the graph build path uses to
     /// derive top-m semantic edges from the already-built hnsw graph without
     /// re-running an O(n^2) exact knn. The neighbor SET is the build-order
@@ -37,7 +37,7 @@ impl HnswIndex {
             .unwrap_or(&[])
     }
 
-    /// lSearch for the `ef` closest candidates to `q`. Returns ids only —
+    /// Search for the `ef` closest candidates to `q`. Returns ids only —
     /// the runtime reranks with the exact dot product to produce the
     /// final cosine score.
     pub fn search(&self, q: &[f32], ef: usize) -> Vec<usize> {
@@ -67,7 +67,7 @@ impl HnswIndex {
     }
 }
 
-/// lGreedy descent on a single layer until no neighbor is closer.
+/// Greedy descent on a single layer until no neighbor is closer.
 pub(super) fn greedy_search(
     entry: u32,
     q: &[f32],
@@ -102,7 +102,7 @@ pub(super) fn greedy_search(
     }
 }
 
-/// lSearch a single layer with a candidate list of size `ef`. Returns
+/// Search a single layer with a candidate list of size `ef`. Returns
 /// the best `ef` candidates sorted ascending by distance.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn layer_search(

--- a/crates/nest-runtime/src/ann/select_neighbors.rs
+++ b/crates/nest-runtime/src/ann/select_neighbors.rs
@@ -20,8 +20,8 @@
 use super::{Candidate, cosine_dist};
 use crate::materialize::PackedVectors;
 
-/// lAlgorithm 3: keep the `m` closest candidates by distance ascending.
-/// lStable: ties break by ascending id so the same candidate set + same
+/// Algorithm 3: keep the `m` closest candidates by distance ascending.
+/// Stable: ties break by ascending id so the same candidate set + same
 /// `m` always returns the same neighbor list (required for reproducible
 /// builds). Kept as a reference baseline and for unit tests; build calls
 /// the heuristic.
@@ -38,7 +38,7 @@ pub(super) fn select_neighbors_simple(candidates: &[Candidate], m: usize) -> Vec
     sorted.into_iter().map(|c| c.id).collect()
 }
 
-/// lAlgorithm 4 (Malkov & Yashunin 2018): heuristic neighbor selection
+/// Algorithm 4 (Malkov & Yashunin 2018): heuristic neighbor selection
 /// with diversity.
 ///
 /// `candidates` are pre-scored against the query (the node being inserted
@@ -48,7 +48,7 @@ pub(super) fn select_neighbors_simple(candidates: &[Candidate], m: usize) -> Vec
 /// default in build to guarantee neighbor lists actually reach `m` even
 /// when most candidates get shadowed.
 ///
-/// lDeterminism: ties in distance break by ascending id so the same
+/// Determinism: ties in distance break by ascending id so the same
 /// inputs always produce the same output ordering.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn select_neighbors_heuristic(

--- a/crates/nest-runtime/src/blobs.rs
+++ b/crates/nest-runtime/src/blobs.rs
@@ -13,7 +13,7 @@ use nest_format::sections::{
 
 use crate::error::RuntimeError;
 
-/// lOpen the blob pair. Returns the decoded 0x14 table (`None` when the
+/// Open the blob pair. Returns the decoded 0x14 table (`None` when the
 /// capability or section is absent). When the 0x16 overlay is present,
 /// per-chunk spans that point into a blob REPLACE the decoded 0x03 spans
 /// in place (for a media corpus those carry ordinal placeholders), so

--- a/crates/nest-runtime/src/bm25/codec.rs
+++ b/crates/nest-runtime/src/bm25/codec.rs
@@ -17,7 +17,7 @@ use super::index::{BM25_PAYLOAD_VERSION, Bm25Index, Posting, TermEntry};
 use crate::error::RuntimeError;
 
 impl Bm25Index {
-    /// lEncode for storage in section `0x08` (v2).
+    /// Encode for storage in section `0x08` (v2).
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut out = Vec::new();
         out.extend_from_slice(&BM25_PAYLOAD_VERSION.to_le_bytes());

--- a/crates/nest-runtime/src/bm25/fusion.rs
+++ b/crates/nest-runtime/src/bm25/fusion.rs
@@ -4,12 +4,12 @@
 
 use std::collections::HashMap;
 
-/// lRRF k constant. 60 is the value from the original Cormack et al.
+/// RRF k constant. 60 is the value from the original Cormack et al.
 /// paper; small enough that the top items dominate, large enough to
 /// not be a brittle tie-breaker.
 const RRF_K: f32 = 60.0;
 
-/// lReciprocal-rank fusion of two ranked candidate lists. Returns the
+/// Reciprocal-rank fusion of two ranked candidate lists. Returns the
 /// union sorted by RRF score descending. The runtime then reranks with
 /// the exact dot product so the final scores are real cosine.
 pub fn rrf_union(a: &[usize], b: &[usize]) -> Vec<usize> {

--- a/crates/nest-runtime/src/bm25/index.rs
+++ b/crates/nest-runtime/src/bm25/index.rs
@@ -39,7 +39,7 @@ pub struct Bm25Index {
 }
 
 impl Bm25Index {
-    /// lBuild a BM25 index from the canonical chunk texts.
+    /// Build a BM25 index from the canonical chunk texts.
     pub fn build(docs: &[String], k1: f32, b: f32) -> Self {
         let n_docs = docs.len();
         let mut doc_lengths = Vec::with_capacity(n_docs);
@@ -94,7 +94,7 @@ impl Bm25Index {
         }
     }
 
-    /// lScore `query_text` against the corpus, return the top-k `(doc, score)`
+    /// Score `query_text` against the corpus, return the top-k `(doc, score)`
     /// pairs. Empty query returns an empty vec.
     pub fn search(&self, query_text: &str, k: usize) -> Vec<(usize, f32)> {
         if k == 0 || self.n_docs == 0 {

--- a/crates/nest-runtime/src/bm25/tokenize.rs
+++ b/crates/nest-runtime/src/bm25/tokenize.rs
@@ -2,8 +2,8 @@
 //! search path. Lowercase, split on non-alphanumeric, drop tokens of
 //! length < 2.
 
-/// lLowercase, split on non-alphanumerics, drop tokens of length < 2.
-/// lUnicode-aware: handles PT-BR accents (ã, ç, õ) by virtue of `char`
+/// Lowercase, split on non-alphanumerics, drop tokens of length < 2.
+/// Unicode-aware: handles PT-BR accents (ã, ç, õ) by virtue of `char`
 /// iteration. Simple but effective enough for fake-news / news corpora.
 pub(crate) fn tokenize(s: &str) -> Vec<String> {
     let mut out: Vec<String> = Vec::new();

--- a/crates/nest-runtime/src/dtype.rs
+++ b/crates/nest-runtime/src/dtype.rs
@@ -5,7 +5,7 @@ use nest_format::NestError;
 
 use crate::error::RuntimeError;
 
-/// lRuntime view of the embeddings section dtype.
+/// Runtime view of the embeddings section dtype.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum DType {
     Float32,
@@ -26,7 +26,7 @@ impl DType {
             ))),
         }
     }
-    /// lNominal on-disk bytes per stored embedding value. int4 packs two
+    /// Nominal on-disk bytes per stored embedding value. int4 packs two
     /// codes per byte (rounds to 0 here); the exact section size, with the
     /// f16 group scales, is `expected_embeddings_size`.
     pub fn bytes_per_value(self) -> usize {

--- a/crates/nest-runtime/src/inspect.rs
+++ b/crates/nest-runtime/src/inspect.rs
@@ -12,7 +12,7 @@ use crate::error::RuntimeError;
 use crate::mmap_file::MmapNestFile;
 
 impl MmapNestFile {
-    /// lDecode the stored canonical text for every chunk, in file order. this
+    /// Decode the stored canonical text for every chunk, in file order. this
     /// is the TIER-1 citation text, the same bytes `nest cite` returns, NOT
     /// the original source bytes. re-parses the mmap and decodes the
     /// chunks_canonical (0x02) section (handles zstd / txt_streams / dict /
@@ -25,14 +25,14 @@ impl MmapNestFile {
             .map_err(RuntimeError::Format)
     }
 
-    /// lThe per-chunk ids in file order, parallel to `canonical_texts()`.
+    /// The per-chunk ids in file order, parallel to `canonical_texts()`.
     /// lets a caller build a chunk_id -> canonical-text map without re-reading
     /// the file (the ids are already decoded and held at open time).
     pub fn chunk_ids(&self) -> &[String] {
         &self.chunk_ids
     }
 
-    /// lRe-parse the mmap and return a JSON document mirroring `nest
+    /// Re-parse the mmap and return a JSON document mirroring `nest
     /// inspect`: header fields, section table entries, manifest, hashes,
     /// and the runtime SIMD backend.
     pub fn inspect_json(&self) -> Result<String, RuntimeError> {
@@ -76,7 +76,7 @@ impl MmapNestFile {
         serde_json::to_string(&doc).map_err(|e| RuntimeError::Format(NestError::Json(e)))
     }
 
-    /// lThe space_table (0x15) as a JSON array (`null` when the file has no
+    /// The space_table (0x15) as a JSON array (`null` when the file has no
     /// multimodal capability): one object per named space with its band
     /// geometry, so `inspect --json` consumers (stats, the model bench)
     /// see every queryable space without opening the bands.
@@ -100,7 +100,7 @@ impl MmapNestFile {
         }
     }
 
-    /// lThe blob_refs (0x14) table as a JSON array (`null` when the file
+    /// The blob_refs (0x14) table as a JSON array (`null` when the file
     /// has no blob capability): one object per blob with its content hash
     /// as `sha256:<hex>`, the uri hint, original byte length, and whether
     /// the bytes are inlined in this .nest.

--- a/crates/nest-runtime/src/lib.rs
+++ b/crates/nest-runtime/src/lib.rs
@@ -46,7 +46,7 @@ pub struct SearchHit {
     pub citation_id: String,
 }
 
-/// lWhat precision the mandatory exact-cosine rerank read its vectors from.
+/// What precision the mandatory exact-cosine rerank read its vectors from.
 /// the honesty backbone of `--disclose explain` and `retrieve()`: every
 /// returned `score` IS a real cosine, but at WHICH precision depends on
 /// whether a full-precision `embeddings_fp` (0x09) slab is present.
@@ -64,16 +64,16 @@ pub struct SearchHit {
 /// newcomer is never shown a stored-precision number as full-precision.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RerankSourceKind {
-    /// lscore recomputed against a full-precision source (0x09 fp slab, or
+    /// score recomputed against a full-precision source (0x09 fp slab, or
     /// the stored slab when the stored dtype is already float32).
     FullPrecision,
-    /// lscore recomputed against the lossy stored slab (float16/int8/int4),
+    /// score recomputed against the lossy stored slab (float16/int8/int4),
     /// no fp source present. disclosed as "real cosine at stored precision".
     StoredPrecision,
 }
 
 impl RerankSourceKind {
-    /// lclassify the precision the rerank reads from by its effective dtype
+    /// classify the precision the rerank reads from by its effective dtype
     /// (the 0x09 fp slab's dtype when present, else the stored dtype). only
     /// float32 is full-precision; float16/int8/int4 are stored-precision.
     /// this is the single source of the honesty marker.
@@ -84,14 +84,14 @@ impl RerankSourceKind {
         }
     }
 
-    /// lthe one-line honesty marker for `--disclose explain` / `retrieve()`.
+    /// the one-line honesty marker for `--disclose explain` / `retrieve()`.
     pub fn disclosure(self) -> &'static str {
         match self {
             Self::FullPrecision => "real cosine",
             Self::StoredPrecision => "real cosine at stored precision",
         }
     }
-    /// lstable machine token for the json answer-pack / SearchExplain.
+    /// stable machine token for the json answer-pack / SearchExplain.
     pub fn as_str(self) -> &'static str {
         match self {
             Self::FullPrecision => "full_precision",
@@ -100,7 +100,7 @@ impl RerankSourceKind {
     }
 }
 
-/// lADDITIVE per-search provenance, attached to every `SearchResult`. zero
+/// ADDITIVE per-search provenance, attached to every `SearchResult`. zero
 /// format bytes, no `NEST_FORMAT_VERSION` bump: it is computed entirely in
 /// the runtime from the search path and the open file. feeds the lens
 /// `--disclose explain` honesty line and the agent-native `retrieve()`
@@ -113,29 +113,29 @@ impl RerankSourceKind {
 /// we never claim a recall we did not measure.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SearchExplain {
-    /// lthe route taken: "exact" | "hnsw" | "graph" | "hybrid".
+    /// the route taken: "exact" | "hnsw" | "graph" | "hybrid".
     pub route: &'static str,
-    /// lexact-flat candidates considered (the whole corpus on the exact path
+    /// exact-flat candidates considered (the whole corpus on the exact path
     /// and the graph seed path; 0 when the path used an ann shortlist).
     pub exact_candidates: usize,
-    /// lann shortlist size (hnsw / hybrid vector path); 0 otherwise.
+    /// ann shortlist size (hnsw / hybrid vector path); 0 otherwise.
     pub ann_candidates: usize,
-    /// lbm25 lexical shortlist size (hybrid path); 0 otherwise.
+    /// bm25 lexical shortlist size (hybrid path); 0 otherwise.
     pub bm25_candidates: usize,
-    /// lgraph bfs frontier union size (graph path); 0 otherwise.
+    /// graph bfs frontier union size (graph path); 0 otherwise.
     pub graph_candidates: usize,
-    /// lhow the candidate lists were combined: "none" | "rrf".
+    /// how the candidate lists were combined: "none" | "rrf".
     pub fusion_mode: &'static str,
-    /// lthe precision the mandatory exact rerank read from. the honesty
+    /// the precision the mandatory exact rerank read from. the honesty
     /// backbone: see `RerankSourceKind`.
     pub rerank_source: RerankSourceKind,
-    /// l`1.0` on the exact path, `NaN` on every candidate-generating path
+    /// `1.0` on the exact path, `NaN` on every candidate-generating path
     /// (we never claim a recall we did not measure).
     pub recall_estimate: f32,
 }
 
 impl SearchExplain {
-    /// lthe exact-flat path: the whole corpus scored, recall=1.0 ground
+    /// the exact-flat path: the whole corpus scored, recall=1.0 ground
     /// truth, no fusion.
     pub(crate) fn exact(n: usize, src: RerankSourceKind) -> Self {
         Self {
@@ -150,7 +150,7 @@ impl SearchExplain {
         }
     }
 
-    /// lthe hnsw path: an ann shortlist into the exact rerank, recall=NaN.
+    /// the hnsw path: an ann shortlist into the exact rerank, recall=NaN.
     pub(crate) fn hnsw(ann: usize, src: RerankSourceKind) -> Self {
         Self {
             route: "hnsw",
@@ -164,7 +164,7 @@ impl SearchExplain {
         }
     }
 
-    /// lthe graph path: exact-cosine top-ef seed, bfs frontier union into
+    /// the graph path: exact-cosine top-ef seed, bfs frontier union into
     /// the exact rerank, recall=NaN.
     pub(crate) fn graph(seed: usize, frontier: usize, src: RerankSourceKind) -> Self {
         Self {
@@ -179,7 +179,7 @@ impl SearchExplain {
         }
     }
 
-    /// lthe hybrid path: vector (ann or exact) ∪ bm25, rrf fusion into the
+    /// the hybrid path: vector (ann or exact) ∪ bm25, rrf fusion into the
     /// exact rerank, recall=NaN.
     pub(crate) fn hybrid(ann: usize, exact: usize, bm25: usize, src: RerankSourceKind) -> Self {
         Self {
@@ -204,7 +204,7 @@ pub struct SearchResult {
     pub truncated: bool,
     pub k_requested: i32,
     pub k_returned: usize,
-    /// lADDITIVE per-search provenance (route, candidate counts, fusion
+    /// ADDITIVE per-search provenance (route, candidate counts, fusion
     /// mode, rerank-source honesty marker, recall estimate). no format
     /// bytes; computed in the runtime. see `SearchExplain`.
     pub explain: SearchExplain,

--- a/crates/nest-runtime/src/materialize.rs
+++ b/crates/nest-runtime/src/materialize.rs
@@ -15,11 +15,11 @@ use nest_format::{INT4_BLOCK, Int4EmbeddingsView, Int8EmbeddingsView, NestError,
 
 use crate::error::RuntimeError;
 
-/// lEmbedding rows in their on-disk packing, decoded to f32 one row at a
+/// Embedding rows in their on-disk packing, decoded to f32 one row at a
 /// time. `float32` is kept as-is (it is not the leak); `float16` and
 /// `int8` stay packed and decode into a scratch buffer on demand.
 pub(crate) enum PackedVectors {
-    /// lNot yet attached (graph parsed from disk, vectors pending).
+    /// Not yet attached (graph parsed from disk, vectors pending).
     Empty,
     F32(Vec<f32>),
     F16(Vec<u8>),
@@ -27,7 +27,7 @@ pub(crate) enum PackedVectors {
         data: Vec<i8>,
         scales: Vec<f32>,
     },
-    /// lint4 block-64: codes stay as i8 in `[-7, 7]` (one per dim) and the
+    /// int4 block-64: codes stay as i8 in `[-7, 7]` (one per dim) and the
     /// per-group f16 scales are kept as f32 (`blocks` per row). A row
     /// decodes to `code * group_scale`, matching the int4 view exactly.
     Int4 {
@@ -46,7 +46,7 @@ impl PackedVectors {
         !matches!(self, PackedVectors::Empty)
     }
 
-    /// lBuild a packed store from a decoded embeddings section. Copies the
+    /// Build a packed store from a decoded embeddings section. Copies the
     /// section into its packed form (compact for int8/float16); never the
     /// `n * dim * 4` f32 expansion the old `materialize_f32_vectors` did.
     pub(crate) fn from_section(
@@ -105,7 +105,7 @@ impl PackedVectors {
         }
     }
 
-    /// lA scratch buffer sized for one decoded row, or empty for the f32
+    /// A scratch buffer sized for one decoded row, or empty for the f32
     /// store (which borrows its rows directly and never touches scratch).
     pub(crate) fn scratch(&self, dim: usize) -> Vec<f32> {
         match self {
@@ -114,7 +114,7 @@ impl PackedVectors {
         }
     }
 
-    /// lRow `i` decoded to f32. For `F32` this borrows the stored slice and
+    /// Row `i` decoded to f32. For `F32` this borrows the stored slice and
     /// ignores `scratch`; for `F16`/`Int8` it decodes into `scratch` and
     /// returns that, using the SAME arithmetic the whole-buffer path used
     /// (`f16::to_f32`, `int8 as f32 * scale`) so distances are unchanged.

--- a/crates/nest-runtime/src/mmap_cold.rs
+++ b/crates/nest-runtime/src/mmap_cold.rs
@@ -4,7 +4,7 @@
 use crate::mmap_file::MmapNestFile;
 
 impl MmapNestFile {
-    /// lHint to the OS that the mmap pages won't be needed soon. The
+    /// Hint to the OS that the mmap pages won't be needed soon. The
     /// next read will fault them back in from disk.
     ///
     /// **Caveat:** this is `posix_madvise(MADV_DONTNEED)` — an
@@ -31,7 +31,7 @@ impl MmapNestFile {
         }
     }
 
-    /// lNo-op on non-Unix platforms.
+    /// No-op on non-Unix platforms.
     #[cfg(not(unix))]
     pub fn madvise_cold(&self) {}
 }

--- a/crates/nest-runtime/src/mmap_file.rs
+++ b/crates/nest-runtime/src/mmap_file.rs
@@ -28,40 +28,40 @@ pub struct MmapNestFile {
     pub(crate) embedding_dim: usize,
     pub(crate) n_embeddings: usize,
     pub(crate) dtype: DType,
-    /// lByte offset (within the mmap) of the embeddings section payload.
+    /// Byte offset (within the mmap) of the embeddings section payload.
     pub(crate) embeddings_offset: usize,
-    /// lTotal physical bytes of the embeddings section.
+    /// Total physical bytes of the embeddings section.
     pub(crate) embeddings_size: usize,
-    /// lOptional full-precision rerank slab (`embeddings_fp`, 0x09): when
+    /// Optional full-precision rerank slab (`embeddings_fp`, 0x09): when
     /// present the exact rerank reads it instead of the stored dtype slab.
     pub(crate) embeddings_fp: Option<FpSlab>,
     pub(crate) chunk_ids: Vec<String>,
     pub(crate) spans: Vec<OriginalSpan>,
     pub(crate) embedding_model: String,
-    /// lManifest `model_hash`: the granular fingerprint of the model that
+    /// Manifest `model_hash`: the granular fingerprint of the model that
     /// produced the corpus embeddings. Exposed so a caller embedding a query
     /// can verify its embedder matches the corpus (the honesty gate).
     pub(crate) model_hash: String,
     pub(crate) file_hash: String,
     pub(crate) content_hash: String,
-    /// lOptional ANN index. Built from the HNSW section payload at open
+    /// Optional ANN index. Built from the HNSW section payload at open
     /// time (eager: build cost is paid once, queries get fast path).
     pub(crate) ann_index: Option<ann::HnswIndex>,
-    /// lOptional BM25 index. Mostly tiny ints; deserialized eagerly.
+    /// Optional BM25 index. Mostly tiny ints; deserialized eagerly.
     pub(crate) bm25_index: Option<bm25::Bm25Index>,
-    /// lOptional chunk-to-chunk graph (graph_adjacency 0x0C). Opened behind
+    /// Optional chunk-to-chunk graph (graph_adjacency 0x0C). Opened behind
     /// the manifest `graph_present` capability, like ann/bm25. A candidate
     /// generator only: its frontier feeds the exact rerank, never a score.
     pub(crate) graph_index: Option<CsrIndex>,
-    /// lOptional blob_refs (0x14) table, opened behind the additive
+    /// Optional blob_refs (0x14) table, opened behind the additive
     /// `blobs_present` capability. content-hash references to the source
     /// media blobs (self-contained or catalog).
     pub(crate) blob_refs: Option<Vec<BlobRefRecord>>,
-    /// lOptional multimodal spaces (0x15 + bands), opened behind the
+    /// Optional multimodal spaces (0x15 + bands), opened behind the
     /// additive `supports_multimodal` capability. each space's band slab
     /// is scored by the per-space exact search, never by the text path.
     pub(crate) spaces: Option<Vec<crate::spaces::OpenSpace>>,
-    /// lWhat the manifest says the search path is. The runtime honors
+    /// What the manifest says the search path is. The runtime honors
     /// this at search time.
     pub(crate) declared_index_type: String,
     pub(crate) declared_score_type: String,
@@ -204,7 +204,7 @@ impl MmapNestFile {
     pub fn declared_index_type(&self) -> &str {
         &self.declared_index_type
     }
-    /// lManifest `model_hash` (the model fingerprint the corpus was built
+    /// Manifest `model_hash` (the model fingerprint the corpus was built
     /// with). Callers embed the query with their own model and compare.
     pub fn model_hash(&self) -> &str {
         &self.model_hash
@@ -224,7 +224,7 @@ impl MmapNestFile {
     pub fn has_blobs(&self) -> bool {
         self.blob_refs.is_some()
     }
-    /// lThe blob_refs (0x14) table, when the file declares `blobs_present`:
+    /// The blob_refs (0x14) table, when the file declares `blobs_present`:
     /// content-hash references to the source media blobs, in table order
     /// (the overlay's `blob_ref_index` addresses this slice).
     pub fn blob_refs(&self) -> Option<&[BlobRefRecord]> {
@@ -233,7 +233,7 @@ impl MmapNestFile {
     pub fn has_spaces(&self) -> bool {
         self.spaces.is_some()
     }
-    /// lNames of the multimodal spaces listed in the space_table (empty
+    /// Names of the multimodal spaces listed in the space_table (empty
     /// when the file has no `supports_multimodal` capability).
     pub fn space_names(&self) -> Vec<&str> {
         self.spaces
@@ -243,7 +243,7 @@ impl MmapNestFile {
             .map(|s| s.entry.name.as_str())
             .collect()
     }
-    /// lOne opened space by name, with its band slab sliced off the mmap.
+    /// One opened space by name, with its band slab sliced off the mmap.
     pub(crate) fn space(&self, name: &str) -> Option<(&crate::spaces::OpenSpace, &[u8])> {
         let s = self
             .spaces
@@ -253,7 +253,7 @@ impl MmapNestFile {
         Some((s, &self._mmap[s.offset..s.offset + s.size]))
     }
 
-    /// lRe-run all reader-side validation. The file was already
+    /// Re-run all reader-side validation. The file was already
     /// validated at `open()` time, but callers can invoke this
     /// explicitly to detect tampering after the fact (e.g. the mmap
     /// pages got swapped under the runtime).
@@ -268,7 +268,7 @@ impl MmapNestFile {
         &self._mmap[self.embeddings_offset..self.embeddings_offset + self.embeddings_size]
     }
 
-    /// lThe full-precision rerank slab + its dtype, if an `embeddings_fp`
+    /// The full-precision rerank slab + its dtype, if an `embeddings_fp`
     /// (0x09) section is present. The rerank handle prefers this over the
     /// stored dtype slab so a sub-int8 corpus still returns a real cosine.
     pub(crate) fn embeddings_fp_slab(&self) -> Option<(&[u8], DType)> {

--- a/crates/nest-runtime/src/rerank.rs
+++ b/crates/nest-runtime/src/rerank.rs
@@ -31,7 +31,7 @@ use crate::dtype::DType;
 use crate::error::RuntimeError;
 use crate::simd;
 
-/// lThe optional full-precision rerank slab (`embeddings_fp`, section
+/// The optional full-precision rerank slab (`embeddings_fp`, section
 /// `0x09`): a fixed-stride 64-byte-aligned raw slab, NEVER zstd, one row
 /// per embedding. Present only when a sub-int8 candidate slab needs an
 /// honest exact rerank. The dtype (float32 or float16 only) is read back
@@ -46,7 +46,7 @@ pub(crate) struct FpSlab {
 }
 
 impl FpSlab {
-    /// lDetect an `embeddings_fp` (0x09) section in the table and infer its
+    /// Detect an `embeddings_fp` (0x09) section in the table and infer its
     /// dtype from stride: 4 bytes/value -> float32, 2 -> float16 (an fp
     /// source is never int8). A bad stride is a malformed file, not a
     /// silent skip. Returns `None` when the section is absent.
@@ -81,7 +81,7 @@ impl FpSlab {
     }
 }
 
-/// lWhere one rerank reads its vectors from. Built once per search call,
+/// Where one rerank reads its vectors from. Built once per search call,
 /// then `score`d per candidate. Borrows the mmap slab; no copy.
 pub(crate) struct RerankSource<'a> {
     rows: RerankRows<'a>,
@@ -96,7 +96,7 @@ enum RerankRows<'a> {
 }
 
 impl<'a> RerankSource<'a> {
-    /// lBuild a rerank source over a fixed-stride embeddings slab. `bytes`
+    /// Build a rerank source over a fixed-stride embeddings slab. `bytes`
     /// is the raw section payload for `dtype` (for int8 that includes the
     /// per-vector scale prefix, parsed here once).
     pub(crate) fn new(
@@ -118,7 +118,7 @@ impl<'a> RerankSource<'a> {
         Ok(Self { rows, dim })
     }
 
-    /// lReal cosine of `qnorm` against row `i` at this source's precision.
+    /// Real cosine of `qnorm` against row `i` at this source's precision.
     /// `qnorm` is L2-normalized and rows are L2-normalized at write time,
     /// so the dot product IS the cosine.
     #[inline]
@@ -168,7 +168,7 @@ mod tests {
         assert!(src.score(&q, 1).abs() < 1e-6);
     }
 
-    /// lThe handle scores whatever slab it is handed. A full-precision fp
+    /// The handle scores whatever slab it is handed. A full-precision fp
     /// slab returns the exact dot; the int8 slab over the SAME logical
     /// vector returns a quantized approximation. They differ, which is
     /// exactly why an fp rerank source makes a sub-int8 score honest.
@@ -199,7 +199,7 @@ mod tests {
         assert!((f16.score(&q, 0) - 1.0).abs() < 1e-2);
     }
 
-    /// lThe int4 rerank source scores a known row, and an fp source over the
+    /// The int4 rerank source scores a known row, and an fp source over the
     /// same logical vector is strictly more precise. int4 is the coarser
     /// stored precision, so its self-similarity drifts further from 1.0 than
     /// the exact fp source does, which is exactly why int4 must disclose

--- a/crates/nest-runtime/src/search.rs
+++ b/crates/nest-runtime/src/search.rs
@@ -9,7 +9,7 @@ use crate::rerank::RerankSource;
 use crate::{RerankSourceKind, SearchExplain, SearchHit, SearchResult};
 
 impl MmapNestFile {
-    /// lthe honesty marker: the precision the rerank reads from, from the
+    /// the honesty marker: the precision the rerank reads from, from the
     /// `embeddings_fp` (0x09) slab dtype when present, else the stored dtype.
     fn rerank_source_kind(&self) -> RerankSourceKind {
         let dtype = self
@@ -19,7 +19,7 @@ impl MmapNestFile {
         RerankSourceKind::from_dtype(dtype)
     }
 
-    /// lValidate query, L2-normalize, return the normalized vector.
+    /// Validate query, L2-normalize, return the normalized vector.
     fn validate_query(&self, query: &[f32], k: i32) -> Result<Vec<f32>, RuntimeError> {
         if k <= 0 {
             return Err(RuntimeError::InvalidK(k));
@@ -49,7 +49,7 @@ impl MmapNestFile {
         Ok(qnorm)
     }
 
-    /// lThe single rerank source the exact-cosine recompute reads from:
+    /// The single rerank source the exact-cosine recompute reads from:
     /// the full-precision `embeddings_fp` (0x09) slab when present, else
     /// the stored dtype slab. Both `score_all` and `score_subset` route
     /// through this so every path's returned score is the SAME real
@@ -62,7 +62,7 @@ impl MmapNestFile {
         RerankSource::new(dtype, bytes, self.n_embeddings, self.embedding_dim)
     }
 
-    /// lScore every chunk against `qnorm` via the rerank source. Returns
+    /// Score every chunk against `qnorm` via the rerank source. Returns
     /// `(idx, score)` pairs in the natural index order.
     fn score_all(&self, qnorm: &[f32]) -> Result<Vec<(usize, f32)>, RuntimeError> {
         let n = self.n_embeddings;
@@ -74,7 +74,7 @@ impl MmapNestFile {
         Ok(scores)
     }
 
-    /// lScore a sliced subset of indices (used by ANN/BM25 rerank). The
+    /// Score a sliced subset of indices (used by ANN/BM25 rerank). The
     /// returned vector mirrors `idxs.len()` in order. This IS the exact
     /// rerank every candidate-generating path must end in.
     fn score_subset(
@@ -90,7 +90,7 @@ impl MmapNestFile {
         Ok(out)
     }
 
-    /// lExact flat search. The recall=1.0 ground truth.
+    /// Exact flat search. The recall=1.0 ground truth.
     pub fn search(&self, query: &[f32], k: i32) -> Result<SearchResult, RuntimeError> {
         let t0 = std::time::Instant::now();
         let qnorm = self.validate_query(query, k)?;
@@ -112,7 +112,7 @@ impl MmapNestFile {
         })
     }
 
-    /// lANN search. Pulls `ef_search` candidates from HNSW, reranks with
+    /// ANN search. Pulls `ef_search` candidates from HNSW, reranks with
     /// the exact dot product, returns top-k. Falls back to `search()` if
     /// no ANN section is present.
     pub fn search_ann(
@@ -148,7 +148,7 @@ impl MmapNestFile {
         })
     }
 
-    /// lGraph search: seed from the exact-cosine top-`ef`, expand a bounded
+    /// Graph search: seed from the exact-cosine top-`ef`, expand a bounded
     /// bfs over the chunk-to-chunk csr, union seed + frontier, then run the
     /// SAME mandatory exact rerank on the union. the graph ONLY generates
     /// candidates; the returned score is real cosine, identical contract to
@@ -200,9 +200,9 @@ impl MmapNestFile {
         })
     }
 
-    /// lHybrid search: BM25 candidates ∪ ANN (or exact) candidates,
+    /// Hybrid search: BM25 candidates ∪ ANN (or exact) candidates,
     /// reciprocal-rank fusion, then exact cosine rerank on the union.
-    /// lFinal score is the real cosine.
+    /// Final score is the real cosine.
     pub fn search_hybrid(
         &self,
         query_vec: &[f32],

--- a/crates/nest-runtime/src/simd/avx2.rs
+++ b/crates/nest-runtime/src/simd/avx2.rs
@@ -32,7 +32,7 @@ pub(super) unsafe fn dot_f32_avx2(q: &[f32], row_bytes: &[u8]) -> f32 {
     }
 }
 
-/// lFused dequant + dot for int4 block-`block` codes. AVX2 unpacks the
+/// Fused dequant + dot for int4 block-`block` codes. AVX2 unpacks the
 /// nibbles 16 packed bytes (32 nibbles) at a time into an f32 scratch row,
 /// then runs the IDENTICAL per-group scalar reduction over it (float add
 /// is not associative, so a lane-parallel reduction would diverge from the
@@ -79,7 +79,7 @@ pub(super) unsafe fn dot_f32_i4_avx2(
     }
 }
 
-/// lArithmetic shift right by 4 on packed i8 lanes (AVX2 has no epi8 SRA),
+/// Arithmetic shift right by 4 on packed i8 lanes (AVX2 has no epi8 SRA),
 /// emulated via the epi16 SRA plus a byte-wise blend of even/odd lanes.
 #[target_feature(enable = "avx2,fma")]
 // This body is pure register-only intrinsics (no memory I/O). On our MSRV
@@ -107,7 +107,7 @@ unsafe fn mm_srai_epi8_4(v: std::arch::x86_64::__m128i) -> std::arch::x86_64::__
     }
 }
 
-/// lWiden an i8x16 vector to f32 and store into `out[..16]`.
+/// Widen an i8x16 vector to f32 and store into `out[..16]`.
 #[target_feature(enable = "avx2,fma")]
 unsafe fn store_i8x16_as_f32(v: std::arch::x86_64::__m128i, out: &mut [f32]) {
     unsafe {
@@ -119,7 +119,7 @@ unsafe fn store_i8x16_as_f32(v: std::arch::x86_64::__m128i, out: &mut [f32]) {
     }
 }
 
-/// lPer-group reduction over an already-dequantized f32 scratch row,
+/// Per-group reduction over an already-dequantized f32 scratch row,
 /// matching `scalar::dot_f32_i4_blocked` operation-for-operation.
 #[inline]
 fn dot_scratch_blocked(

--- a/crates/nest-runtime/src/simd/scalar.rs
+++ b/crates/nest-runtime/src/simd/scalar.rs
@@ -39,7 +39,7 @@ pub fn dot_f32_i8_scalar(q: &[f32], row: &[i8]) -> f32 {
     acc
 }
 
-/// lSign-extend a 4-bit nibble (low 4 bits of `b`) to f32 in `[-8, 7]`.
+/// Sign-extend a 4-bit nibble (low 4 bits of `b`) to f32 in `[-8, 7]`.
 #[inline]
 fn nib_to_f32(b: u8) -> f32 {
     let n = b & 0x0F;
@@ -51,7 +51,7 @@ fn nib_to_f32(b: u8) -> f32 {
     s as f32
 }
 
-/// lFused dequant + dot for int4 block-`block` codes against an f32 query.
+/// Fused dequant + dot for int4 block-`block` codes against an f32 query.
 /// `codes` is `dim/2` packed bytes (two nibbles each, low nibble first);
 /// `group_scales` is one f32 per `block`-dim group. Each component
 /// contributes `q[j] * code[j] * group_scales[j / block]`, accumulated in

--- a/crates/nest-runtime/src/space_search.rs
+++ b/crates/nest-runtime/src/space_search.rs
@@ -15,7 +15,7 @@ use crate::search::sort_scores_desc;
 use crate::{RerankSourceKind, SearchExplain, SearchResult};
 
 impl MmapNestFile {
-    /// lExact flat search over one named multimodal space (e.g. "vision").
+    /// Exact flat search over one named multimodal space (e.g. "vision").
     /// the query must be embedded with the model the space's
     /// `model_hash` fingerprints and have the space's dim; both are
     /// checked up front (the per-space honesty gate), so a text-tower

--- a/crates/nest-runtime/src/spaces.rs
+++ b/crates/nest-runtime/src/spaces.rs
@@ -11,7 +11,7 @@ use nest_format::sections::{SpaceEntry, decode_space_table};
 
 use crate::error::RuntimeError;
 
-/// lone opened space: its directory entry plus the byte range of its band
+/// one opened space: its directory entry plus the byte range of its band
 /// slab inside the mmap (resolved once at open time).
 #[derive(Clone, Debug)]
 pub(crate) struct OpenSpace {
@@ -20,7 +20,7 @@ pub(crate) struct OpenSpace {
     pub size: usize,
 }
 
-/// lOpen the space_table and resolve each listed space's band range.
+/// Open the space_table and resolve each listed space's band range.
 /// `None` when the capability or the section is absent. the band's
 /// presence and exact size were already validated by the reader
 /// (`validate_space_bands`), so a missing band here is a typed error,

--- a/crates/nest-runtime/tests/hnsw_recall.rs
+++ b/crates/nest-runtime/tests/hnsw_recall.rs
@@ -28,7 +28,7 @@ use std::collections::HashSet;
 
 use nest_runtime::ann::{DEFAULT_EF_CONSTRUCTION, DEFAULT_M, HnswIndex};
 
-/// lTiny LCG (deterministic) for synthetic corpora.
+/// Tiny LCG (deterministic) for synthetic corpora.
 struct Lcg(u64);
 impl Lcg {
     fn new(seed: u64) -> Self {
@@ -156,7 +156,7 @@ fn hnsw_recall_at_1_synthetic() {
     );
 }
 
-/// lRealistic-sized corpus (n=10_000, dim=384). Mirrors the production
+/// Realistic-sized corpus (n=10_000, dim=384). Mirrors the production
 /// shape. Uses ef_search=400 (= default ef_construction) so the runtime
 /// has a candidate budget commensurate with the corpus. Slow in debug;
 /// run via `cargo test --release` in CI.

--- a/crates/nest-runtime/tests/rerank_contract.rs
+++ b/crates/nest-runtime/tests/rerank_contract.rs
@@ -63,7 +63,7 @@ fn random_l2(n: usize, dim: usize, seed: u64) -> Vec<f32> {
     v
 }
 
-/// lBuild a .nest carrying an HNSW (0x07) and a BM25 (0x08) section over a
+/// Build a .nest carrying an HNSW (0x07) and a BM25 (0x08) section over a
 /// synthetic f32 corpus, so `search_ann` and `search_hybrid` exercise the
 /// real candidate paths rather than falling back to exact.
 fn build_indexed_corpus(path: &PathBuf, n: usize, dim: usize) -> Vec<f32> {
@@ -139,7 +139,7 @@ fn tmp_path(name: &str) -> PathBuf {
     p
 }
 
-/// lA non-exact search path: its name and a thunk that runs it. The list
+/// A non-exact search path: its name and a thunk that runs it. The list
 /// of these is the honesty gate; new verbs must join it.
 type NonExactPath<'a> = (&'a str, Box<dyn Fn() -> SearchResult + 'a>);
 
@@ -243,7 +243,7 @@ fn non_exact_paths_return_real_cosine_byte_for_byte_and_recall_is_nan() {
     let _ = std::fs::remove_file(&path);
 }
 
-/// lThe additive `SearchExplain` is populated on all four paths with the
+/// The additive `SearchExplain` is populated on all four paths with the
 /// right route, candidate counts, and rerank-source honesty marker. the
 /// f32 synthetic corpus has no 0x09 fp slab and a float32 stored dtype, so
 /// the rerank source is `FullPrecision` (= "real cosine"). recall_estimate
@@ -297,7 +297,7 @@ fn search_explain_is_populated_on_all_four_paths_with_full_precision() {
     let _ = std::fs::remove_file(&path);
 }
 
-/// lWith no 0x09 fp slab and a lossy stored dtype the rerank source is
+/// With no 0x09 fp slab and a lossy stored dtype the rerank source is
 /// `StoredPrecision` (= "real cosine at stored precision"), AND the returned
 /// score still equals `score_subset` byte-for-byte (the gate the WO names).
 /// an int8 corpus exercises this: the marker discloses stored precision yet


### PR DESCRIPTION
A stray `l` had been prepended to the text of ~270 `///` doc comments (e.g. `/// lInspect file metadata`). Mechanical fix, doc-comment text only, no code changes.

Verified with `grep -rE '^\s*/// l[A-Z`]' crates` returning zero matches after the change.