### PR TITLE
docs: strip the stray 'l' prefix left in forge-core doc comments

### DIFF
--- a/forge-core/src/fci/blob_ref.rs
+++ b/forge-core/src/fci/blob_ref.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 /// A reference to an original source artifact addressed by content-hash.
 ///
-/// lin the default self-contained mode `inlined=true` and the original
+/// in the default self-contained mode `inlined=true` and the original
 /// bytes live inside the .nest; in catalog mode `inlined=false` and the
 /// heavy bytes stay out-of-line while this record keeps the digest,
 /// uri-hint, and length so a citation can reopen and verify them later.

--- a/forge-core/src/fci/embedding_request.rs
+++ b/forge-core/src/fci/embedding_request.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
-/// The named embedding space a request targets. `text` is space[0] and is
+/// The named embedding space a request targets. `text` is `space[0]` and is
 /// always the canonical text space; `image`/`glyph`/`symbol` are the
 /// multimodal carriers a later phase routes per modality.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/forge-core/src/fci/mod.rs
+++ b/forge-core/src/fci/mod.rs
@@ -31,7 +31,7 @@ pub const FCI_SCHEMA_VERSION: u32 = 1;
 /// canonical input yields byte-identical .fci, the upstream half of nest's
 /// reproducible build.
 ///
-/// lfield order is fixed by declaration and the serializer is compact, so
+/// field order is fixed by declaration and the serializer is compact, so
 /// `to_canonical_bytes` is stable across machines for the same content.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct FciBundle {

--- a/forge-core/src/fci/record.rs
+++ b/forge-core/src/fci/record.rs
@@ -7,14 +7,14 @@ use serde::{Deserialize, Serialize};
 /// adapter maps it 1:1 to a `ChunkSpec` and the byte spans round-trip
 /// through `nest cite`.
 ///
-/// lforge-core does NOT chunk. producing these records is extraction;
+/// forge-core does NOT chunk. producing these records is extraction;
 /// splitting their canonical text into chunk-sized records is the python
 /// adapter's call to the ONE authoritative chunker, `builder.chunk_text`.
 /// keeping this struct byte-for-byte the shape of `ChunkSpec` is what lets
 /// `nest.chunk_id` over a `ChunkRecord` equal the id over the matching
 /// `ChunkSpec`, which a golden adapter test (forge-0b) locks.
 ///
-/// lthe byte span indexes into the UTF-8 of the NORMALIZED source text;
+/// the byte span indexes into the UTF-8 of the NORMALIZED source text;
 /// extractors are responsible for producing NFC canonical text, and the
 /// .fci stores it verbatim so the derived chunk_id never desyncs.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
#105 landed the 22 uppercase-initial cases of the stray `l` prefix in forge-core. four lowercase-initial ones survived because the earlier grep only matched `/// l[A-Z]`:

- `/// lin the default self-contained mode ...` (blob_ref.rs)
- `/// lfield order is fixed by declaration ...` (fci/mod.rs)
- `/// lforge-core does NOT chunk ...` and `/// lthe byte span indexes ...` (record.rs)

also wraps `space[0]` in backticks in `embedding_request.rs` so rustdoc stops reporting an unresolved link. doc text only, no code change.

verified: `grep -rnE '^\s*//[/!] l([A-Z`]|(in|field|forge|the)\b)' --include='*.rs' crates forge-core` returns nothing; `cargo doc --no-deps --manifest-path forge-core/Cargo.toml` builds with zero warnings.