### PR TITLE
update git ignore with demo tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ fuzz/coverage/
 
 # competitor benchmark scratch stores (python/tools/bench_competitors.py --work)
 .bench-competitors/
+tools/


### PR DESCRIPTION
ignores `tools/` (local demo tooling). this commit was sitting on the local `main` ahead of `origin/main`; the ruleset only accepts pull requests, so it lands through one.