### PR TITLE
docs: close hardening-plan 4.6 (fp slab writer) as a decision, not a feature

### DIFF
--- a/doc/hardening-plan.md
+++ b/doc/hardening-plan.md
@@ -172,14 +172,33 @@ packing is exact; and every encoder is byte-stable across two calls. these
 are the byte-identity claims the citation URI depends on; before this they
 were tested on fixed inputs only.
 
-### 4.6 write the 0x09 fp slab
+### 4.6 write the 0x09 fp slab (decision 2026-09-10: not as a preset; reader stays)
 
-the runtime reranks from `embeddings_fp` when present, but no writer emits
-it, so an int4 corpus reranks at stored precision and every hit discloses
-that. `NestFileBuilder::embeddings_fp(EmbeddingDType::Float16)` writes the
-64-byte-aligned raw slab next to the int4 section; `nano` preset gains it;
-measure_presets gets the recall delta. this closes the honesty-disclosure
-gap instead of documenting it.
+the item assumed the slab would sit next to the int4 section as a rerank
+source while int4 kept generating candidates. reading the runtime says
+otherwise: `rerank_source()` in `search.rs` routes BOTH `score_all` (the
+exact path) and `score_subset` (ann / graph / hybrid rerank) through the
+fp slab whenever it is present, and `RerankSourceKind::from_dtype` calls
+only float32 "full precision" (float16 is stored precision). so a file
+with int4 + fp slab reads the int4 rows for one thing only, the graph's
+materialized distances, and pays for both slabs:
+
+| stored + slab | bytes / dim | rerank disclosure | ladder point it competes with |
+|---|---|---|---|
+| int4 + f16 slab | 2.5 | still "stored precision" (f16) | `compressed` (f16 stored, 2.0, recall 1.000) |
+| int4 + f32 slab | 4.5 | "real cosine" | `exact` (f32 stored, 4.0, recall 1.000) |
+| int8 (`tiny`) | 1.0 | "stored precision" | recall 0.992 at ratio 0.256 |
+
+neither combination is a pareto point: `tiny` already gives 0.992 at
+1 byte/dim, and the only way the slab earns its bytes is a two-stage exact
+path (coarse scan over the stored rows, fp rerank of the top candidates),
+which turns "exact" into approximate-with-exact-scores and is a contract
+change, not a hardening item. decision: no writer, no `nano-fp` preset.
+the reader path stays as is (a file produced elsewhere with a 0x09 slab
+is honored and validated), the disclosure stays honest, and `nano` keeps
+saying "real cosine at stored precision". reopen only with a corpus where
+the int4 scan + fp rerank shape is measured to beat `tiny` on the same
+recall.
 
 ### 4.7 kernel benchmarks in-repo (done)
 


### PR DESCRIPTION
hardening-plan §4.6 asked for a writer for the 0x09 `embeddings_fp` slab so an int4 corpus stops reranking at stored precision. before writing it I read the runtime side, and the premise does not hold:

- `rerank_source()` (`crates/nest-runtime/src/search.rs`) routes both the exact scan and the ann / graph / hybrid rerank through the fp slab whenever it is present, so the int4 rows are only read to materialize the graph's distances; the file pays for both slabs.
- `RerankSourceKind::from_dtype` treats only float32 as full precision. an f16 slab (2.5 bytes/dim with the int4) would still disclose "stored precision" and competes with `compressed` (f16 stored, 2.0 bytes/dim, recall 1.000); an f32 slab (4.5 bytes/dim) competes with `exact` (4.0). `tiny` (int8, 1.0 byte/dim) already measures 0.992 recall.

the only design where the slab earns its bytes is a two-stage exact path (coarse scan on the stored rows, fp rerank of the top candidates), which changes what "exact" means and is not a hardening item.

decision recorded in the plan: no writer, no `nano-fp` preset; the reader path and the honest disclosure stay as they are; reopen only with a corpus where that two-stage shape is measured to beat `tiny` at the same recall. no code change.